### PR TITLE
Updates to section ordering on index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,10 @@
           border-bottom: 1px solid #efefef;
       }
 
+      .state:first-child {
+          padding-top: 25px;
+      }
+
       .state h2 {
           font-size: 28px;
           padding-top: 20px;
@@ -102,18 +106,15 @@
           margin-bottom: -10px;
       }
 
-      .filters-list {
-          margin-bottom: 30px;
-      }
-
       .filters-list div {
           display: inline-block;
       }
 
       .filters-list h4 {
-          font-size: 20px;
+          font-size: 16px;
+          font-weight: 600;
           text-transform: uppercase;
-          margin-top: 30px;
+          margin-top: 15px;
           margin-bottom: 10px;
       }
 
@@ -125,7 +126,7 @@
           border: 1px #aadaff solid;
           background: #aadaff30;
           font-size: 18px;
-          padding: 0.3rem 0.4rem;
+          padding: 0.2rem 0.4rem;
           cursor: pointer;
           border-radius: 3px;
       }
@@ -136,6 +137,11 @@
 
       .filters-list label.selected {
           background-color: #aadaff;
+      }
+
+      .map-container {
+          padding-top: 30px;
+          padding-bottom: 5px;
       }
 
       #map {
@@ -162,7 +168,7 @@
       }
 
       .locations-loading {
-        text-align: center;
+        padding-top: 20px;
       }
       .load-spinner {
         width: 21px;
@@ -199,7 +205,8 @@
     <div class="container" style="padding-bottom: 40px;">
         <h1 style="padding: 20px 0px 0px 0px;">#findthemasks</h1>
         <p style="padding: 0px;">This site is part of the <a href="https://getusppe.org/">getusppe.org</a> coalition.</p>
-        <h4 style="padding-bottom: 20px; font-weight: 400;">America&rsquo;s frontline healthcare workers are treating COVID19 patients, in some cases without adequate protective gear. Some have taken to Twitter on <a href="https://twitter.com/search?q=%23GetMePPE&src=typeahead_click">#GetMePPE</a> to ask for help.</h4>
+        <h4 style="padding-bottom: 20px; font-weight: 400;">America&rsquo;s frontline healthcare workers are treating COVID-19 patients, in some cases without adequate protective gear.
+          Some have taken to Twitter on <a href="https://twitter.com/search?q=%23GetMePPE&src=typeahead_click">#GetMePPE</a> to ask for help.</h4>
 
         <p style="padding-top: 10px; margin: 0px;">We need to help the helpers, right now.</p>
         <h3 style="padding-bottom: 20px">We need to find the masks.</h3>
@@ -208,7 +215,10 @@
         If you find surgical masks, those are also in short supply, and in many places are being used in place of N95s.
         All of these masks can save lives now if you get them into the hands of health care workers.</p>
 
-      <p>Other types of PPE like disposable <span class=embold>booties</span>, <span class=embold>safety goggles</span>, and <span class=embold>disposable suits</span> are also in short supply. If you have these things or know someone who might (HVAC installers? Construction workers?) please share this site with them. Large donors can register at <a href="https://getusppe.org/">getusppe.org/give</a>.</p>
+      <p>Other types of PPE like disposable <span class=embold>booties</span>, <span class=embold>safety goggles</span>, and
+        <span class=embold>disposable suits</span> are also in short supply. If you have these things or know someone who might
+        (HVAC installers? Construction workers?) please share this site with them. Large donors can register at
+        <a href="https://getusppe.org/">getusppe.org/give</a>.</p>
 
 
         <a name="sites"></a>
@@ -216,32 +226,37 @@
         <ol>
             <li> Look at our list of sites below. You can filter by state or supplies needed.
             <li> If there's a site near you, drop off following their instructions.
-            <li> If you are donating open packages, please put them in a ziploc bag with a note saying whether they have been used, whether anyone in your household has been sick or travelled outside the country, and the expiration date if known.
+            <li> If you are donating open packages, please put them in a ziploc bag with a note saying whether they have been
+          used, whether anyone in your household has been sick or travelled outside the country, and the expiration date if known.
             <li> If there's not a site near you, visit <a href="https://getusppe.org/give">getusppe.org</a> to let them know what you have available.
         </ol>
-        <h5>To add a donation site, update information, or request we take down information, please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfgCpK5coPVFC6rJrE7ZhimiZuDoEaL6fo6gYqxsN_FIpJZhg/viewform">fill in this form</a>.</h5>
+        <h5>To add a donation site, update information, or request we take down information, please
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfgCpK5coPVFC6rJrE7ZhimiZuDoEaL6fo6gYqxsN_FIpJZhg/viewform">fill in this form</a>.</h5>
 
-        <div class="map-container" style="display: none;">
-          <h3 style="padding: 30px 0px 20px 0px;"><span class="i18n" data-i18n="ftm-map-of-sites">Map of donation sites</span> <span id="map-stats"></span></h3>
-          <div id="map"></div>
-        </div>
+
 
         <div class="locations-loading">
           <img src="images/icons/loader.svg" alt="" class="load-spinner"> Loading donation sites...
         </div>
 
         <div class="locations-container" style="display: none;">
+          <h3 style="padding-top: 30px; padding-bottom: 10px;">Donation sites <span id="list-stats"></span></h3>
+
           <div class="filters-container" style="display: none;">
-            <h3 style="padding: 30px 0px 20px 0px;">List of donation sites <span id="list-stats"></span></h3>
-            <h4>Filters</h4>
             <form name="filters" class="filters-list"></form>
+          </div>
+
+          <div class="map-container" style="display: none;">
+            <div id="map"></div>
           </div>
 
           <div id="locations-list" class="locations-list"></div>
         </div>
 
-        <p style="padding-top: 30px;">To add a donation site, update information, or request we take down information, please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfgCpK5coPVFC6rJrE7ZhimiZuDoEaL6fo6gYqxsN_FIpJZhg/viewform">fill in this form</a>.<br><br>
-        Got a comment or suggestion not related to data updates? Want to help? contact@findthemasks.com or join us on <a href="https://github.com/r-pop/findthemasks">our Github</a>.</p>
+        <p style="padding-top: 30px;">To add a donation site, update information, or request we take down information, please
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfgCpK5coPVFC6rJrE7ZhimiZuDoEaL6fo6gYqxsN_FIpJZhg/viewform">fill in this form</a>.<br><br>
+        Got a comment or suggestion not related to data updates? Want to help? contact@findthemasks.com or join us on
+          <a href="https://github.com/r-pop/findthemasks">our Github</a>.</p>
         <p class="centerText">made with &lt;3 in Seattle</p>
         <a href="whoweare.html" class="end">who we are</a>
     </div>

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -279,12 +279,13 @@ window.onFilterChange = function (elem, scrollNeeded) {
 
   const filters = { states, acceptItems };
   const locationsList = $(".locations-list");
+  const mapContainer = $(".map-container");
 
   locationsList.empty().append(getFilteredContent(data_by_location, filters));
   showMarkers(data_by_location, filters, false);
 
   if (scrollNeeded) {
-    locationsList[0].scrollIntoView({'behavior': 'smooth'});
+    mapContainer[0].scrollIntoView({'behavior': 'smooth'});
   }
 };
 


### PR DESCRIPTION
Now that the filters update both the map and the list, I'm re-ordering the Donations section to be:
- filters
- map
- list

We then display only one list count, and a single "Donation sites (num)" header.

This works with ?hide-map and ?hide-filters.

However, this breaks the "?hide-list" option, but that's not a big issue on index.