### PR TITLE
Linkify instructions at usage point

### DIFF
--- a/public/give.html
+++ b/public/give.html
@@ -19,6 +19,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.i18n/1.0.7/jquery.i18n.emitter.bidi.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.i18n/1.0.7/jquery.i18n.emitter.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-element.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-html.min.js"></script>
     <script src="i18n.js"></script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.i18n/1.0.7/jquery.i18n.emitter.bidi.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.i18n/1.0.7/jquery.i18n.emitter.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-element.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-html.min.js"></script>
     <script src="i18n.js"></script>
 

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -117,7 +117,7 @@ function createContent(data, showList, showMap) {
           if (entry.instructions) {
             entry.domElem.append([
               ce('label', null, ctn($.i18n('ftm-instructions'))),
-              ce('p', null, ctn(entry.instructions))
+              linkifyElement(ce('p', null, ctn(entry.instructions)))
             ]);
           }
 
@@ -451,7 +451,7 @@ function addMarkerToMap(map, latitude, longitude, address, name, instructions, a
     var contentString =
         '<h5>' + name + '</h5>' +
         `<div class="label">${$.i18n('ftm-maps-marker-address-label')}</div><div class=value>` + address + '</div>' +
-        `<div class="label">${$.i18n('ftm-maps-marker-instructions-label')}</div><div class=value>` + instructions + '</div>' +
+        `<div class="label">${$.i18n('ftm-maps-marker-instructions-label')}</div><div class=value>` + linkifyHtml(instructions) + '</div>' +
         `<div class="label">${$.i18n('ftm-maps-marker-accepting-label')}</div><div class=value>` + accepting + '</div>' +
         `<div class="label">${$.i18n('ftm-maps-marker-open-packages-label')}</div><div class=value>` + open_accepted + '</div>';
 

--- a/public/toDataByLocation.js
+++ b/public/toDataByLocation.js
@@ -17,8 +17,6 @@ export default function toDataByLocation(data) {
     const entry_array = city_obj.entries;
     const entry_obj = {};
 
-    entry[instructionsIndex] = linkifyHtml(entry[instructionsIndex]);
-
     headers.forEach( (value, index) => {
       if (entry[index] !== undefined) {
         entry_obj[value] = entry[index];


### PR DESCRIPTION
Fix for the list view being generated via createElement / createTextNode. Links in the instructions paragraph need to be linkified after the element exists, or the HTML gets treated as plain text.

A little unfortunate the same instructions in the map marker infowindow gets processed as HTML string, but at least both instances work now.