### PR TITLE
Dedup cities in parsed data

### DIFF
--- a/public/toDataByLocation.js
+++ b/public/toDataByLocation.js
@@ -3,14 +3,13 @@ export default function toDataByLocation(data) {
   const approvedIndex = headers.findIndex( e => e === 'approved' );
   const stateIndex = headers.findIndex( e => e === 'state' );
   const cityIndex = headers.findIndex( e => e === 'city' );
-  const instructionsIndex = headers.findIndex( e => e === 'instructions' );
   const data_by_location = {};
 
   const published_entries = data.values.slice(1).filter((entry) => entry[approvedIndex] === "x");
 
   published_entries.forEach( entry => {
-    const state = entry[stateIndex].trim();
-    const city = entry[cityIndex].trim();
+    const state = entry[stateIndex].trim().toUpperCase();
+    const city = entry[cityIndex].trim().toLowerCase();
 
     const state_obj = data_by_location[state] = (data_by_location[state] || { cities: {} });
     const city_obj = state_obj.cities[city] = (state_obj.cities[city] || { entries: [] });


### PR DESCRIPTION
Raw data doesn't have consistent case in the Cities field, so we can wind up with duplicate entries in the rendered list.