### PR TITLE
Dynamic maps key: Proof of concept method of loading google maps with a dynamic API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Join the slack! <https://join.slack.com/t/findthemasks/shared_invite/zt-czdjjznp
 ?hide-map={true/false}
 ?hide-filters={true/false}
 ?hide-list={true/false} (also hides filters)
+?mapsKey={custom Google Maps API key}
 ```
 
 All boolean parameters default to false.

--- a/public/give.html
+++ b/public/give.html
@@ -23,7 +23,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-html.min.js"></script>
     <script src="i18n.js"></script>
 
-    <script defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDSz0lnzPJIFeWM7SpSARHmV-snwrAXd2s&libraries=geometry"></script>
     <script type="module" src="locations-list-map.js"></script>
 
     <title>#Findthemasks</title>
@@ -43,12 +42,12 @@
     <meta lang="en" property="og:title" content="#findthemasks | Give"/>
     <meta lang="en" property="og:url" content="https://findthemasks.com/give.html"/>
     <meta lang="en" property="og:description" content="America’s frontline healthcare workers are treating COVID-19 patients without adequate protective gear, risking their lives! We need to find the masks. All of these masks can save lives now if you get them into the hands of healthcare workers."/>
-    
+
     <!-- French -->
     <meta lang="fr" property="og:title" content="#findthemasks | Give"/>
     <meta lang="fr" property="og:url" content="https://findthemasks.com/give.html"/>
     <meta lang="fr" property="og:description" content="Les travailleurs de la santé de première ligne du monde entier traitent les patients atteints de COVID-19 sans équipement de protection adéquat, risquant leur vie! Nous devons trouver les masques. Tous ces masques peuvent maintenant sauver des vies si vous les remettez entre les mains de professionnels de la santé."/>
-    
+
     <meta property="og:image" content="https://findthemasks.com/images/n95.jpg"/>
     <meta property="og:type" content="website"/>
     <!-- END Open Graph Tags -->


### PR DESCRIPTION
Just a proof of concept method of loading google maps with a dynamic API key. This is very hacky right now due to the inter-dependencies of the rest of the code that rely on maps even though technically the map may actually be hidden. So, right now we **must** load the maps API even if the map isn't displaying, so this has to cope with that by loading maps at the root module context.

Use `?mapsApi=[your key]` to override the maps key.

Since this is a hack, I don't necessarily expect this to be merged but wanted to put it out there as inspiration for a better executed version! 😄 It will become increasingly necessary as we deploy more map updates to Heroku (which is not capable of loading our maps API with special wildcards like `findthemasks-*.herokuapp.com/*` given limitations on Google's side). 

Clone `git@github.com:patricknelson/findthemasks.git` and checkout `dynamic-maps-api` to continue with this code.