### PR TITLE
Do not map entries that have no geocodes

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -141,7 +141,9 @@ function createContent(data, showList, showMap) {
           const lat = Number(entry.lat);
           const lng = Number(entry.lng);
 
-          if (!isNaN(lat)) {
+          if (isNaN(lat) || isNaN(lng) || !lat || !lng) {
+            console.log('skipped mapping entry w/o geocode: ', entry)
+          } else {
             entry.marker = addMarkerToMap(null, lat, lng, entry.address, entry.name, entry.instructions, entry.accepting, entry.open_box);
           }
         }


### PR DESCRIPTION
The geocoder takes time. Entries can be approved, but not yet located. In that case, don't show them on the map because they end up in the ocean off the coast of Ghana.