### PR TITLE
Center the map on the US by default.

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -391,7 +391,7 @@ function initMap(stateFilter) {
     stateFilter = null;
   }
 
-  map = new google.maps.Map(element);
+  map = new google.maps.Map(element, { center: inital_center, zoom: initial_zoom });
 
   showMarkers(data_by_location, { states: stateFilter }, !stateFilter);
 


### PR DESCRIPTION
This is a very quick workaround fo #271.

It doesn't actually make the geolocation call non-blocking, but gives the map an initial center and zoom so it will render markers and show a map instead of a grey box while the geolocation prompt is still open.