### PR TITLE
Add filters state object

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,7 @@
 
       .filters-list div {
           display: inline-block;
+          margin-right: 0.5ex;
       }
 
       .filters-list h4 {

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -395,8 +395,8 @@ function loadMapScript(searchParams, filters) {
 function initMap(filters) {
   const element = document.getElementById('map');
 
-  if (!element ) {
-    return
+  if (!element) {
+    return;
   }
 
   $(".map-container").show();


### PR DESCRIPTION
Revamp of how the active filters are tracked, for both map and list. There's now a data object that tracks the available filters and their current states. The UX elements are created based on this object (or not, if hide-list and/or hide-filters are set). State is synced between the UX elements and any ?state= params on page load.

Fixes some jank in onFilterChanged, especially WRT calling it directly at startup to handle ?state= settings.

Also simplifies the "Reset map" behavior, since it can just revert to what the filters object holds, instead of tracking the initial filters separately.

Fixes #304 