### PR TITLE
Do not render the list of sites until i18n is loaded

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -15,6 +15,7 @@ $(function () {
     // translate static elements and initialize translations
     // then, remove spinner and show page content
     $('.i18n').i18n();
+    window.i18nReady = true;
     $('html').trigger('i18n:ready');
     $('.translated-content').css({display: 'block'});
     $('.languages-loading').css({display: 'none'});

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -329,8 +329,7 @@ $(function () {
     countryDataFilename = `data-${country}.json`;
   }
 
-
-  $.getJSON(`https://findthemasks.com/${countryDataFilename}`, function (result) {
+  const renderListings = function(result) {
     // may end up using this for search / filtering...
     window.locations = result;
     window.data_by_location = toDataByLocation(locations);
@@ -388,6 +387,16 @@ $(function () {
       }
 
       $(".locations-list").empty().append(getFilteredContent(data_by_location, filters));
+    }
+  };
+
+  $.getJSON(`https://findthemasks.com/${countryDataFilename}`, function (result) {
+    if(window.i18nReady) {
+      renderListings(result);
+    } else {
+      $('html').on('i18n:ready', function() {
+        renderListings(result);
+      });
     }
   });
 });


### PR DESCRIPTION
Now that we are loading the strings with XHR, there is occasionally a race condition where data.json is loaded before the translations. This only shows up for countries with a small amount of data. This PR should fix it to wait until strings are loaded to render any content that depends on them.