### PR TITLE
Add GA tracking for clicking map filters

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -160,7 +160,7 @@ function createFilterElements(filters) {
     const label = ce('label', null, ctn(value));
     label.id = `${ prefix }-${ key }-label`;
     label.htmlFor = input.id;
-    label.addEventListener("click", () =>  sendEvent("Map", `filter-${ prefix }`, key));
+    label.addEventListener("click", () =>  sendEvent("map", `filter-${ prefix }`, key));
     filterContainer.appendChild(label);
 
     if (filter.isSet) {

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -138,6 +138,14 @@ function updateFilters(filters) {
   }
 }
 
+// Sends event to gtag for analytics
+function sendEvent(category, action, label) {
+  gtag('event', action, {
+    'event_category': category,
+    'event_label': label
+  });
+};
+
 function createFilterElements(filters) {
   const container = ce('div');
 
@@ -152,6 +160,7 @@ function createFilterElements(filters) {
     const label = ce('label', null, ctn(value));
     label.id = `${ prefix }-${ key }-label`;
     label.htmlFor = input.id;
+    label.addEventListener("click", () =>  sendEvent("Map", `filter-${ prefix }`, key));
     filterContainer.appendChild(label);
 
     if (filter.isSet) {


### PR DESCRIPTION
Adds tracking for the equipment and state map filters.

Everytime a map filter is created created an analytics event with these properies:
**Category**: `map`
**Action**: `filter-getItems` or `filter-states`
**Label**: key of the filter clicked (i.e. `WA` or `mask`)