### PR TITLE
Slack's website preview always uses french

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,15 +41,15 @@
 
     <!-- START Open Graph Tags -->
 
-    <!-- French -->
-    <meta lang="fr" property="og:title" content="#findthemasks"/>
-    <meta lang="fr" property="og:url" content="https://findthemasks.com/"/>
-    <meta lang="fr" property="og:description" content="Les travailleurs de la santé de première ligne du monde entier traitent les patients atteints de COVID-19 sans équipement de protection adéquat, risquant leur vie! Nous devons trouver les masques. Tous ces masques peuvent maintenant sauver des vies si vous les remettez entre les mains de professionnels de la santé."/>
-
     <!-- English -->
     <meta lang="en" property="og:title" content="#findthemasks"/>
     <meta lang="en" property="og:url" content="https://findthemasks.com/"/>
     <meta lang="en" property="og:description" content="Find where you can donate your masks or other personal protective equipment (PPE) in your local area."/>
+
+    <!-- French -->
+    <meta lang="fr" property="og:title" content="#findthemasks"/>
+    <meta lang="fr" property="og:url" content="https://findthemasks.com/"/>
+    <meta lang="fr" property="og:description" content="Les travailleurs de la santé de première ligne du monde entier traitent les patients atteints de COVID-19 sans équipement de protection adéquat, risquant leur vie! Nous devons trouver les masques. Tous ces masques peuvent maintenant sauver des vies si vous les remettez entre les mains de professionnels de la santé."/>
 
     <meta property="og:image" content="https://findthemasks.com/images/map.jpg"/>
     <meta property="og:type" content="website"/>


### PR DESCRIPTION
I pasted this in slack for coworkers, and it used french for the website description preview. Slack might just be dumb and use the first `<meta property="og:description">` it finds. Swapping language preferences in Slack did not seem to matter. In this case, you might want to put english first.

![image](https://user-images.githubusercontent.com/1810909/77851122-70d00180-7194-11ea-899b-36e047944b44.png)

Tested out the meta tag ordering on a toy site:
![image](https://user-images.githubusercontent.com/1810909/77851260-55b1c180-7195-11ea-850f-cfa5511ca006.png)
