### PR TITLE
Create analytic events for map controls and i18n

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -50,6 +50,7 @@ const generateBottomNav = () => {
       currentUrl.searchParams.set('locale', locale.localeCode);
       element.setAttribute('href', currentUrl.href);
       element.textContent = $.i18n(locale.i18nString);
+      element.addEventListener("click", () =>  sendEvent("i18n", 'set-locale', locale.localeCode));
       localeDropdownItems.appendChild(element);
     });
 
@@ -72,6 +73,7 @@ const generateBottomNav = () => {
         currentUrl.href
       );
       element.textContent = $.i18n(country.i18nString);
+      element.addEventListener("click", () =>  sendEvent("i18n", 'set-country', country.countryCode));
       countryDropdownItems.appendChild(element);
     });
   }

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -152,7 +152,7 @@ function createFilterElements(filters) {
     const label = ce('label', null, ctn(value));
     label.id = `${ prefix }-${ key }-label`;
     label.htmlFor = input.id;
-    label.addEventListener("click", () =>  sendEvent("map", `filter-${ prefix }`, key));
+    label.addEventListener("click", () =>  sendEvent("filters", `${ prefix }`, key));
     filterContainer.appendChild(label);
 
     if (filter.isSet) {
@@ -540,11 +540,13 @@ function initMapSearch(filters) {
   // Setup event listeners for map action links.
   $('#use-location').on('click', (e) => {
     e.preventDefault();
+    sendEvent("map","center","user-location");
     centerMapToMarkersNearUser();
   });
 
   $('#reset-map').on('click', (e) => {
     e.preventDefault();
+    sendEvent("map","reset","default-location");
     resetMap(filters);
   });
 }

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -512,16 +512,18 @@ function initMapSearch(filters) {
   autocomplete.addListener('place_changed', () => {
     let place = autocomplete.getPlace();
     if (place.geometry) {
-      // Get the location object that we can map.setCenter() on.
+      // Get the location object that we can map.setCenter() on
+      sendEvent("map","autocomplete", $search.val());
       let location = place.geometry.location;
       if (location) {
         centerMapToMarkersNearCoords(location.lat(), location.lng())
-
       } else {
+        sendEvent("map","autocomplete-fail", $search.val());
         console.warn('Location data not found in place geometry (place.geometry.location).')
       }
     } else {
       console.warn('No geometry found, attempting geocode...');
+      sendEvent("map","search", $search.val());
 
       // Attempt a geocode of the direct user input instead.
       const geocoder = new google.maps.Geocoder();
@@ -530,10 +532,10 @@ function initMapSearch(filters) {
         // Ensure we got a valid response with an array of at least one result.
         if (status === 'OK' && Array.isArray(results) && results.length > 0) {
           let location = results[0].geometry.location;
-          centerMapToMarkersNearCoords(location.lat(), location.lng())
-
+          centerMapToMarkersNearCoords(location.lat(), location.lng());
         } else {
           console.warn('Geocode failed: ' + status);
+          sendEvent("map","geocode-fail", $search.val());
         }
       });
     }


### PR DESCRIPTION
Creates a GA event when:
- user resets map
- user centers map to their location
- user sets locale
- user sets language
- user does an autocomplete map search
- user does an autocomplete map search and the location is missing
- user does a map search
- user does a map search and we are unable to geocode

Also renames the category of events on the state & equipment filters from `map` to `filters`

Part of https://github.com/findthemasks/findthemasks/issues/317