### PR TITLE
Scroll to map on filter change

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -500,7 +500,16 @@ function onFilterChange(data, prefix, key, filters) {
   locationsList.empty().append(getFilteredContent(data, filters));
   showMarkers(data, filters);
 
-  locationsList[0].scrollIntoView({ 'behavior': 'smooth' });
+  let scrollElem = locationsList[0];
+  const map = document.getElementById('map');
+
+  // Scroll to the map if it exists and is visible
+  if (map && map.offsetHeight) {
+    scrollElem = map;
+  }
+
+
+  scrollElem.scrollIntoView({ 'behavior': 'smooth' });
 };
 
 // Lazy-loads the Google maps script once we know we need it. Sets up

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -499,17 +499,6 @@ function onFilterChange(data, prefix, key, filters) {
   const locationsList = $(".locations-list");
   locationsList.empty().append(getFilteredContent(data, filters));
   showMarkers(data, filters);
-
-  let scrollElem = locationsList[0];
-  const map = document.getElementById('map');
-
-  // Scroll to the map if it exists and is visible
-  if (map && map.offsetHeight) {
-    scrollElem = map;
-  }
-
-
-  scrollElem.scrollIntoView({ 'behavior': 'smooth' });
 };
 
 // Lazy-loads the Google maps script once we know we need it. Sets up


### PR DESCRIPTION
We've gone back and forth on whether changing a filter should scroll to the list, to the map, or not at all. How about a solution where we scroll to the map if it's available, or to the list if the page was created with ?hide-map=true? I'm probably biased since I want to show off the show-others feature, so I'm open to feedback on this behavior...