### PR TITLE
Fixes #264: Clear search field when resetting map.

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -523,7 +523,7 @@ function onFilterChange(data, prefix, key, filters) {
   showMarkers(data, filters);
 
   const locationsList = $(".locations-list");
-  
+
   // locationsList[0].scrollIntoView({ 'behavior': 'smooth' });
 
 };
@@ -658,6 +658,7 @@ function initMapSearch(data, filters) {
   $('#reset-map').on('click', (e) => {
     e.preventDefault();
     resetMap(data, filters);
+    $search.val('');
     sendEvent("map","reset","default-location");
   });
 }


### PR DESCRIPTION
Quick fix for #264, simply clears the text field when resetting the map. Basically the idea is that when you click reset map, it only resets the map itself and the positioning and has nothing to do with filters per se.