### PR TITLE
Clean up CSS

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -4,25 +4,18 @@ html {
 }
 
 body {
+  background: #fff;
   box-sizing: border-box;
+  color: #222;
+  font: normal normal normal 1rem/1.65 'Roboto', 'Helvetica', sans-serif;
   height: 100%;
   margin: 0;
   padding: 0;
-  line-height: 1.65;
-  background-color: #ffffff;
-  color: #222;
-  font-family: 'Roboto', 'Helvetica', sans-serif;
-  font-weight: normal;
-  font-style: normal;
-  font-variant: normal;
   text-rendering: optimizeLegibility;
 }
 
 .content-container {
-  margin-top: 15px;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 40px;
+  margin: 15px auto 40px auto;
   width: 60%;
 }
 
@@ -32,11 +25,10 @@ body {
 }
 
 .heading-container {
-  padding-top: 30px;
-  padding-bottom: 20px;
-  text-align: center;
-  background-color: royalblue;
+  background: royalblue;
   color: white;
+  padding: 30px 0 20px 0;
+  text-align: center;
 }
 
 .heading-container a {
@@ -58,25 +50,20 @@ h1 {
 }
 
 h2 {
-  font-weight: 800;
   color: #333;
-  margin-top: 30px;
-  text-align: center;
   font-size: 1.8rem;
-  margin-bottom: 20px;
+  font-weight: 800;
+  margin: 30px 0 20px 0;
+  text-align: center;
   text-transform: capitalize;
 }
 
 hr {margin-top: 1.7rem;}
 
 .footer {
-  margin-top: 50px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 45px;
-  padding-right: 45px;
-  padding-bottom: 90px;
-  background-color: #eee;
+  background: #eee;
+  margin: 50px auto 0 auto;
+  padding: 0 45px 90px 45px;
 }
 
 .member-of {
@@ -87,10 +74,7 @@ hr {margin-top: 1.7rem;}
 }
 
 .subhead {
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 20px;
-  margin-bottom: 40px;
+  margin: 20px auto 40px auto;
   display: flex;
   align-items: center;
   text-align: center;
@@ -98,24 +82,24 @@ hr {margin-top: 1.7rem;}
   padding: 10px 20px;
   border-radius: 2px;
 }
+
 .subhead-left {
-  width: calc(40% + 40px);
+  border-right: 2px solid #ccc;
+  font-size: 0.9rem;
   font-weight: light;
   letter-spacing: 3px;
-  text-align: right;
-  text-transform: uppercase;
-  font-size: 0.9rem;
   line-height: 1.8rem;
   margin-right: 20px;
-  padding-right: 20px;
-  border-right: 2px solid #ccc;
-  padding-top: 25px;
-  padding-bottom: 25px;
+  padding: 25px 20px 25px 0;
+  text-align: right;
+  text-transform: uppercase;
+  width: calc(40% + 40px);
 }
+
 .subhead-right{
-  width: calc(60% + 40px);
-  text-align: left;
   font-size: 1rem;
+  text-align: left;
+  width: calc(60% + 40px);
 }
 
 .question {
@@ -123,27 +107,22 @@ hr {margin-top: 1.7rem;}
 }
 
 .need-ppe {
-  margin: 40px 0px;
+  background: #fafafa;
   border: 1px solid #ccc;
+  margin: 40px 0px;
   padding: 30px 50px;
   text-align: center;
-  background: #fafafa;
 }
 
 .need-ppe h2 {
   margin-top: 0;
 }
 
-.ppe-container {
-  margin-top: 30px;
-  margin-bottom: 30px;
-}
-
 .ppe-example {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
 }
 
 .ppe-example img {
@@ -166,11 +145,10 @@ hr {margin-top: 1.7rem;}
 .ppe-example-caption {
   color: #444;
   font-size: 12px;
-  letter-spacing: 1.1px;
   font-weight: 300;
+  letter-spacing: 1.1px;
+  margin: 0.9rem 0 0.375rem 0;
   text-transform: uppercase;
-  margin-top: 0.9rem;
-  margin-bottom: 0.375rem;
 }
 
 .social-link {
@@ -178,23 +156,20 @@ hr {margin-top: 1.7rem;}
 }
 
 h2.state {
-  font-size: 24px;
-  display: flex;
-  margin: 0;
-  min-width: 90px;
-  font-weight: 800;
-  font-family: 'Roboto';
-  border: 1px solid #eee;
-  height: 90px;
-  width: 90px;
-  position: absolute;
-  justify-content: center;
   align-items: center;
-  background-color: #333;
+  background: #333;
+  border: 1px solid #eee;
   color: white;
+  display: flex;
+  font: 800 24px 'Roboto';
+  height: 90px;
+  justify-content: center;
   letter-spacing: 3px;
-  margin-right: 15px;
+  margin: 0 15px 0 0;
+  min-width: 90px;
   padding: 0 15px;
+  position: absolute;
+  width: 90px;
   word-break: break-all;
 }
 
@@ -203,15 +178,13 @@ h2.state {
 }
 
 h3.city {
-  font-size: 20px;
-  padding-bottom: 20px;
-  padding-top: 20px;
-  font-weight: 300;
-  margin: 0px;
-  text-transform: uppercase;
   color: #666;
+  font-size: 20px;
+  font-weight: 300;
   letter-spacing: 3px;
-  margin-left: 105px;
+  margin: 0 0 0 105px;
+  padding: 20px 0;
+  text-transform: uppercase;
 }
 
 .locations-list h4 {
@@ -224,7 +197,6 @@ h3.city {
 .locations-list p {
   margin: 0px;
   font-size: 0.9rem;
-
 }
 
 .location {
@@ -236,11 +208,10 @@ h3.city {
 .location label {
   color: #444;
   font-size: 12px;
-  letter-spacing: 1.1px;
   font-weight: 300;
+  letter-spacing: 1.1px;
+  margin: 0.9rem 0 0.375rem 0;
   text-transform: uppercase;
-  margin-top: 0.9rem;
-  margin-bottom: 0.375rem;
 }
 
 .donation-sites h1 {
@@ -249,8 +220,7 @@ h3.city {
 
 .filters-list div {
   display: inline-block;
-  margin-right: 3px;
-  margin-bottom: 3px;
+  margin: 0 3px 3px 0;
 }
 
 .locations-list {
@@ -275,40 +245,38 @@ h3.city {
   display: block;
   font-size: 18px;
   font-weight: 600;
-  margin-top: 25px;
-  margin-bottom: 20px;
+  margin: 25px 0 20px 0;
 }
 
 .filters-list input {
   display: none;
 }
 
-
 .filters-list label {
-  border: 1px #ccc solid;
   background: white;
-  font-size: 18px;
-  padding: 0.3rem 0.4rem;
-  cursor: pointer;
   border-radius: 5px;
+  border: 1px #ccc solid;
+  cursor: pointer;
+  font-size: 18px;
+  min-width: 2.4em;
+  padding: 0.3rem;
+  text-align: center;
 }
 
-
 .filters-list label:hover {
-  background-color:#7c9bf7;
+  background:#7c9bf7;
   border-color: #7c9bf7;
   color: white;
 }
 
 .filters-list label.selected {
-  background-color: royalblue;
-  color: white;
+  background: royalblue;
   border-color: #c2d1ff;
+  color: white;
 }
 
 .map-container {
-  padding-top: 30px;
-  padding-bottom: 5px;
+  padding: 30px 0 5px 0;
 }
 
 #map {
@@ -317,13 +285,12 @@ h3.city {
 }
 
 #map .label {
-  width: 105px;
-  padding-top: 6px;
-  padding-bottom: 2px;
-  text-transform: uppercase;
   color: #999;
   font-size: 11px;
   font-weight: 400;
+  padding: 6px 0 2px 0;
+  text-transform: uppercase;
+  width: 105px;
 }
 
 #map .value {
@@ -331,17 +298,17 @@ h3.city {
 }
 
 #map-stats, #list-stats {
-  font-weight: 300;
-  font-size: 22px;
-  text-align: center;
   color: #333;
+  font-size: 22px;
+  font-weight: 300;
   margin-left: 10px;
   padding-top: 1px;
+  text-align: center;
 }
 
 .donation-map-title {
-  display: flex;
   align-items: center;
+  display: flex;
   justify-content: center;
   text-align: center;
 }
@@ -356,10 +323,10 @@ h3.city {
 }
 
 .load-spinner {
-  width: 21px;
-  height: 21px;
   animation: 5s load-spinner infinite linear;
+  height: 21px;
   vertical-align: text-top;
+  width: 21px;
 }
 
 @-webkit-keyframes load-spinner {
@@ -393,10 +360,10 @@ h3.city {
 
 /* What actually varies with breakpoints */
 .map-search-wrap {
-  width: 100%;
-  position: relative;
-  margin-top: 20px;
   display: flex;
+  margin-top: 20px;
+  position: relative;
+  width: 100%;
 }
 
 .map-search-wrap:first-child {
@@ -404,13 +371,13 @@ h3.city {
 }
 
 .search-icon {
-  top: 1; /* ... see height below... */
-  left: 10px;
-  width: 17px;
   height: 2.3rem; /* synchronized w/ input field for vertical centering, being an SVG it should not warp */
-  position: absolute;
-  pointer-events: none; /* user clicks should fall through to input field instead */
+  left: 10px;
   opacity: 0.7;
+  pointer-events: none; /* user clicks should fall through to input field instead */
+  position: absolute;
+  top: 1; /* ... see height below... */
+  width: 17px;
 }
 
 #map-search {
@@ -423,22 +390,20 @@ h3.city {
 }
 
 #map-search {
-  line-height: 2.3rem;
-  width: 100%;
-  margin-bottom: 5px;
-  /* Set to match the filter labels for consistency. */
-  padding: 0.4rem 0.8rem;
-  padding-left: 35px; /* compensate for search button */
   border-radius: 3px;
+  line-height: 2.3rem;
+  margin-bottom: 5px;
   outline: none;
+  padding: 0.4rem 0.8rem 0.4rem 35px;
+  width: 100%;
 }
 
 .search-input {
-  width: 100%;
-  position: relative;
   display: flex;
-  width:100%;
   margin: 0px 15px 0px 20px;
+  position: relative;
+  width: 100%;
+  width:100%;
 }
 
 .search-controls {


### PR DESCRIPTION
Quick CSS cleanup - sorted properties, merged/eliminated redundant properties, etc.

Added a min-width to the filter labels so the state abbreviations all appear the same size. That's been bugging me for a few days now. :-)