### PR TITLE
Unhandled script exception

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -433,8 +433,6 @@ $(function () {
 
       refreshList(data, filters);
     }
-
-    loadOtherCountries();
   };
 
   $.getJSON(`https://findthemasks.com/${ getCountryDataFilename(currentCountry) }`, function (result) {
@@ -645,6 +643,8 @@ function initMap(data, filters) {
 
   // Initialize autosuggest/search field above the map.
   initMapSearch(data, filters);
+
+  loadOtherCountries();
 }
 
 /**********************************


### PR DESCRIPTION
Move call to loadOtherCountries to after map script loads and map is initialized with the primary markers. Fixes a script exception if the other country data loads before map script loads, or if the map isn't showing at all.