### PR TITLE
Feature/improve map search zooming usability

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -792,8 +792,6 @@ function fitMapToMarkersNearBounds(bounds) {
 
   const markersByDistance = getMarkersByDistanceFrom(center.lat(), center.lng(), 3);
 
-  let hasMarker = false;
-
   // extend bounds to fit closest three markers
   markersByDistance.forEach((marker) => {
       bounds.extend(marker.position);

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -795,15 +795,11 @@ function fitMapToMarkersNearBounds(bounds) {
   let hasMarker = false;
 
   // extend bounds to fit closest three markers
-  [0,1,2].forEach((i) => {
-    const marker = markersByDistance[i];
-    if (marker) {
-      hasMarker = true;
+  markersByDistance.forEach((marker) => {
       bounds.extend(marker.position);
-    }
   });
 
-  if (hasMarker) {
+  if (!bounds.getNorthEast().equals(bounds.getSouthWest())) {
     // zoom to fit user loc + nearest markers
     map.fitBounds(bounds);
   } else {
@@ -835,7 +831,7 @@ function getMarkersByDistanceFrom(latitude, longitude, n=3) {
   // order markerDistances by key (distance)
   let distances = [...markerDistances.keys()].sort((a,b) => a -b);
   // return array of markers in order of distance ascending
-  return distances.map((distance) => markerDistances.get(distance)).slice(0, n);
+  return distances.slice(0, n).map((distance) => markerDistances.get(distance));
 }
 
 /********************************

--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -787,7 +787,8 @@ function centerMapToMarkersNearUser() {
 function fitMapToMarkersNearBounds(bounds) {
   // get center of bounding box and use it to sort markers by distance
   let center = bounds.getCenter();
-  const markersByDistance = getMarkersByDistanceFrom(center.lat(), center.lng());
+
+  const markersByDistance = getMarkersByDistanceFrom(center.lat(), center.lng(), 3);
 
   // extend bounds to fit closest three markers
   [0,1,2].forEach((i) => {
@@ -803,7 +804,7 @@ function fitMapToMarkersNearBounds(bounds) {
 /**
  * Returns a list of markers sorted by distance from an arbitrary set of lat/lng coords.
  */
-function getMarkersByDistanceFrom(latitude, longitude) {
+function getMarkersByDistanceFrom(latitude, longitude, n=3) {
   const latlng = new google.maps.LatLng(latitude, longitude);
 
   const markerDistances = new Map();
@@ -823,14 +824,14 @@ function getMarkersByDistanceFrom(latitude, longitude) {
   // order markerDistances by key (distance)
   let distances = [...markerDistances.keys()].sort((a,b) => a -b);
   // return array of markers in order of distance ascending
-  return distances.map((distance) => markerDistances.get(distance));
+  return distances.map((distance) => markerDistances.get(distance)).slice(0, n);
 }
 
 /**
  * Centers map around markers nearest to an arbitrary set of latitude/longitude coordinates.
  */
 function centerMapToMarkersNearCoords(latitude, longitude) {
-  const markersByDistance = getMarkersByDistanceFrom(latitude, longitude);
+  const markersByDistance = getMarkersByDistanceFrom(latitude, longitude, 3);
 
   // center the map on the user
   const latlng = new google.maps.LatLng(latitude, longitude);


### PR DESCRIPTION
here's the additional changes requested re: pull request #449.

I'm not totally sure I understand what the `hasMarker` functionality actually does -- what is the scenario where we are fitting bounds (either zooming to the user or to a search result) and don't have a marker?