### PR TITLE
Test if cutting out content will improve conversion %

### DIFF
--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -11,40 +11,10 @@
           <!-- <h1>#findthemasks</h1> -->
           <div class="member-of i18n" data-i18n="[html]ftm-index-site-coalition">A member of the <a target="_blank" rel="noreferrer noopener" href="https://www.ppecoalition.com/">PPECoalition</a></div>
       </div>
-
-      <div class="subhead">
-        <div class="subhead-left i18n mr-lg-3 py-2 py-md-4 px-3" data-i18n="ftm-index-need-helpers">Let's
-          Help The Helpers
-        </div>
-        <div class="subhead-right i18n" data-i18n="[html]ftm-index-getmeppe-twitter-cta">
-          Find where you can donate your masks or other personal protective equipment (PPE) in your local
-          area.
-        </div>
-      </div>
-      <div class="container">
-        <div class="row">
-          <div class="col-lg-4 ppe-example">
-            <img id="goggle-img" src="images/goggles.jpg"
-                 alt="example of personal protective equipment: goggles" />
-            <div class="ppe-example-caption i18n" data-i18n="ftm-item-goggles">Safety Goggles</div>
-          </div>
-          <div class="col-lg-4 ppe-example">
-            <img id="masks-img" src="images/masks.jpg"
-                 alt="example of personal protective equipment: surgical mask, N95" />
-            <div class="ppe-example-caption i18n" data-i18n="ftm-item-masks">Surgical mask & N95 Masks
-            </div>
-          </div>
-          <div class="col-lg-4 ppe-example">
-            <img id="faceshield-img" src="images/faceshield.jpg"
-                 alt="example of personal protective equipment: face shield " />
-            <div class="ppe-example-caption i18n" data-i18n="ftm-item-face-shields">Face Shield</div>
-          </div>
-        </div>
-      </div>
-
       <div class="content-container">
-        <h2 class="i18n" data-i18n="ftm-protecting-healthcare-workers">Protecting healthcare workers
-          protects everybody</h2>
+        <h2 class="i18n" data-i18n="ftm-index-getmeppe-twitter-cta">
+          Find where you can donate your masks or other personal protective equipment (PPE) in your local area.
+        </h2>
 
         <p class="i18n" data-i18n="ftm-index-where-to-find-ppe">
           Maybe you bought N95 masks a few weeks ago or already have some in your house. Right now
@@ -92,12 +62,6 @@
 
         {{> (lookup . 'largeDonationSitesPartialPath') }}
 
-        <div class="question i18n" data-i18n="ftm-have-you-donated-question">Have you already donated?
-        </div>
-        <p class="i18n" data-i18n="[html]ftm-have-you-donated-answer">Tell us how you helped by posting on
-          <a target='_blank' class='social-link' rel='noreferrer noopener'
-             href='https://www.facebook.com/findthemasks'><img class='fb-logo' src='images/fb.svg' />
-            findthemasks</a>.</p>
 
         <hr />
 


### PR DESCRIPTION
I would like to bring up the map higher into the page to test if this improves conversion rates so I have cut out some content. Here are the changes: 
- removes the imagery of PPE (I'd like to put this on another page eventually)
- remove the tag line and makes the CTA a direct explanation of what our site does.
- remove line to share with industry friends since we will have share links
- removes the facebook share line since we have a PR to handle share links

The net effect is this brings our two main interactions i) adding a donations site ii) browsing the map, much further up in the page. On desktop you can reac the map in about 2 pages of scrolling now. I'd like to test out if this change will result in a net increase in the % of people who view a donation site on our page. If doesn't improve things I could revert the changes.

I only cut content and didn't edit any phrases to make them more concise since this would cause more work for the translation teams. I also didn't do any CSS stuff since I suck at that, but happy to take suggestions there.

Almost all of these changes are a part of the future design proposed that we will get in the future.