### PR TITLE
Add a little more bottom margin to map

### DIFF
--- a/sass/give.scss
+++ b/sass/give.scss
@@ -275,7 +275,7 @@ h3.city {
 #map {
   height: 400px;
   width: 100%;
-  margin-bottom: .3ex;
+  margin-bottom: .5em;
 }
 
 #map .label {


### PR DESCRIPTION
Text under makers map still a little close.  Up the margin a little more for more space.
Does the same for the donation site map, though there's an inline margin set on the form button overriding everything for that map that expands the margin even further