### PR TITLE
Add Margin Under Map Embed

### DIFF
--- a/public/i18n/ar-ma.json
+++ b/public/i18n/ar-ma.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "تقبل الصناديق / الحقائب المفتوحة",
   "ftm-ack-data-sources" : "يتضمن هذا الموقع أيضًا بيانات من <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> ، مشروع من:",
   "ftm-add-donation-site-question" : "هل تريد الانضمام إلى خريطة #findthemasks؟ هل تحتاج إلى تحديث المعلومات أو إزالتها؟",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> أكمل هذا النموذج </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> أكمل هذا النموذج </button> </a>",
   "ftm-collaboration-with" : "صُنع بالتعاون مع <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "عنوان",
   "ftm-org-type" : "نوع المنظمة",

--- a/public/i18n/de-de.json
+++ b/public/i18n/de-de.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Akzeptanz von bereits geöffneten Verpackungen oder Kartons",
   "ftm-ack-data-sources" : "Diese Site enthält auch Daten von <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , einem Projekt von:",
   "ftm-add-donation-site-question" : "Möchten Sie der # findthemasks-Karte beitreten? Müssen Sie Informationen aktualisieren oder entfernen?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Füllen Sie dieses Formular aus </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Füllen Sie dieses Formular aus </button> </a>",
   "ftm-collaboration-with" : "In Zusammenarbeit mit <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Adresse",
   "ftm-org-type" : "Organisationstyp",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -17,7 +17,7 @@
   "ftm-accepts-open-boxes": "Accepts Opened Boxes/bags",
   "ftm-ack-data-sources": "This site also includes data from <a href=\"https://tinyurl.com/hospitals-needing-ppe\">https://tinyurl.com/hospitals-needing-ppe</a>, a project by:",
   "ftm-add-donation-site-question": "Want to join the #findthemasks map? Need to update or remove info?",
-  "ftm-add-donation-site-answer": "<a class='add-donation-site-form'><button style='margin-top:20px;' type='button' class='btn-sm btn-primary'>Complete this form</button></a>",
+  "ftm-add-donation-site-answer": "<a class='add-donation-site-form'><button type='button' class='btn-sm btn-primary'>Complete this form</button></a>",
   "ftm-collaboration-with": "Made in collaboration with <a href=\".\" target=\"_blank\">#findthemasks</a>.",
   "ftm-address": "Address",
   "ftm-org-type": "Organization Type",

--- a/public/i18n/es-es.json
+++ b/public/i18n/es-es.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Se acepta cajas / bolsas abiertas",
   "ftm-ack-data-sources" : "Este sitio también incluye datos de <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , un proyecto de:",
   "ftm-add-donation-site-question" : "¿Quieres unirte al mapa #findthemasks? ¿Necesita actualizar o eliminar información?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Complete este formulario </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Complete este formulario </button> </a>",
   "ftm-collaboration-with" : "Hecho en colaboración con <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Dirección",
   "ftm-org-type" : "Tipo de organización",

--- a/public/i18n/fr-fr.json
+++ b/public/i18n/fr-fr.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Accepte les boîtes / sacs ouverts",
   "ftm-ack-data-sources" : "Ce site contient également des données de <a href=\"https://tinyurl.com/hospitals-needing-ppe\">https://tinyurl.com/hospitals-needing-ppe</a> un projet de",
   "ftm-add-donation-site-question" : "Vous souhaitez rejoindre la carte #findthemasks? Besoin de mettre à jour ou de supprimer des informations?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Remplissez ce formulaire </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Remplissez ce formulaire </button> </a>",
   "ftm-collaboration-with" : "Fabriqué en collaboration avec <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Adresse",
   "ftm-org-type" : "Type d'Organisation",

--- a/public/i18n/hi-in.json
+++ b/public/i18n/hi-in.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "खोले गए बक्से / बैग स्वीकार करता है",
   "ftm-ack-data-sources" : "इस साइट में <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , एक प्रोजेक्ट का डेटा भी शामिल है:",
   "ftm-add-donation-site-question" : "#Findthemasks मैप में शामिल होना चाहते हैं? जानकारी अपडेट करने या निकालने की आवश्यकता है?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> इस फॉर्म को </button> </a> पूरा करें",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> इस फॉर्म को </button> </a> पूरा करें",
   "ftm-collaboration-with" : "<a href=\".\" target=\"_blank\"> #findthemasks </a> सहयोग से बनाया गया।",
   "ftm-address" : "पता",
   "ftm-org-type" : "संगठन का प्रकार",

--- a/public/i18n/it-it.json
+++ b/public/i18n/it-it.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Accetta scatole / sacchetti aperti",
   "ftm-ack-data-sources" : "Questo sito include anche dati da <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , un progetto di:",
   "ftm-add-donation-site-question" : "Vuoi unirti alla mappa #findthemasks? Devi aggiornare o rimuovere le informazioni?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Compila questo modulo </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Compila questo modulo </button> </a>",
   "ftm-collaboration-with" : "Realizzato in collaborazione con <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Indirizzo",
   "ftm-org-type" : "Tipo di Organizzazione",

--- a/public/i18n/ja-jp.json
+++ b/public/i18n/ja-jp.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "開いたボックス/バッグを受け付けます",
   "ftm-ack-data-sources" : "このサイトには、次のプロジェクト、<a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a>によるデータも含まれています。",
   "ftm-add-donation-site-question" : "#findthemasksマップに参加したいですか？情報を更新または削除する必要がありますか？",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'>このフォームに記入</button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'>このフォームに記入</button> </a>",
   "ftm-collaboration-with" : "<a href=\".\" target=\"_blank\"> #findthemasks </a>と共同で作成されました。",
   "ftm-address" : "住所",
   "ftm-org-type" : "組織タイプ",

--- a/public/i18n/ko-kr.json
+++ b/public/i18n/ko-kr.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "개봉 된 상자 / 가방을 받아들입니다",
   "ftm-ack-data-sources" : "이 사이트에는 다음의 프로젝트 인 <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> 데이터도 포함됩니다.",
   "ftm-add-donation-site-question" : "#findthemasks지도에 가입하고 싶으십니까? 정보를 업데이트하거나 제거해야합니까?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> 이 양식을 작성하십시오 </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> 이 양식을 작성하십시오 </button> </a>",
   "ftm-collaboration-with" : "<a href=\".\" target=\"_blank\"> #findthemasks </a> 와 공동으로 제작되었습니다.",
   "ftm-address" : "주소",
   "ftm-org-type" : "조직 유형",

--- a/public/i18n/nl-nl.json
+++ b/public/i18n/nl-nl.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Accepteert geopende dozen / tassen",
   "ftm-ack-data-sources" : "Deze site bevat ook gegevens van <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , een project van:",
   "ftm-add-donation-site-question" : "Wil je lid worden van de #findthemasks-kaart? Wilt u informatie bijwerken of verwijderen?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Vul dit formulier in </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Vul dit formulier in </button> </a>",
   "ftm-collaboration-with" : "Gemaakt in samenwerking met <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Adres",
   "ftm-org-type" : "organisatie type",

--- a/public/i18n/pl-pl.json
+++ b/public/i18n/pl-pl.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Przyjmuje otwarte pudełka / torby",
   "ftm-ack-data-sources" : "Ta strona zawiera również dane z <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , projektu:",
   "ftm-add-donation-site-question" : "Chcesz dołączyć do mapy #findthemasks? Chcesz zaktualizować lub usunąć informacje?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Wypełnij ten formularz </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Wypełnij ten formularz </button> </a>",
   "ftm-collaboration-with" : "Wykonane we współpracy z <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Adres",
   "ftm-org-type" : "Typ Organizacji",

--- a/public/i18n/pt-pt.json
+++ b/public/i18n/pt-pt.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Aceita caixas abertas / sacolas",
   "ftm-ack-data-sources" : "Este site também inclui dados de <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , um projeto de:",
   "ftm-add-donation-site-question" : "Deseja participar do mapa #findthemasks? Precisa atualizar ou remover informações?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Preencha este formulário </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Preencha este formulário </button> </a>",
   "ftm-collaboration-with" : "Feito em colaboração com <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Endereço",
   "ftm-org-type" : "Tipo de organização",

--- a/public/i18n/ru-ru.json
+++ b/public/i18n/ru-ru.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "Принимает открытые коробки / сумки",
   "ftm-ack-data-sources" : "Этот сайт также содержит данные <a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a> , проекта:",
   "ftm-add-donation-site-question" : "Хотите присоединиться к карте #findthemasks? Нужно обновить или удалить информацию?",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'> Заполните эту форму </button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'> Заполните эту форму </button> </a>",
   "ftm-collaboration-with" : "Сделано в сотрудничестве с <a href=\".\" target=\"_blank\"> #findthemasks </a> .",
   "ftm-address" : "Адрес",
   "ftm-org-type" : "Тип организации",

--- a/public/i18n/zh-tw.json
+++ b/public/i18n/zh-tw.json
@@ -14,7 +14,7 @@
   "ftm-accepts-open-boxes" : "接受打開的盒子/袋子",
   "ftm-ack-data-sources" : "該站點還包含來自<a href=\"https://tinyurl.com/hospitals-needing-ppe\"> https://tinyurl.com/hospitals-needing-ppe </a>數據，該數據來自：",
   "ftm-add-donation-site-question" : "想加入#findthemasks地圖嗎？需要更新或刪除信息嗎？",
-  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button style='margin-top:20px;' type='button' class='btn-sm btn-primary'>填寫此表格</button> </a>",
+  "ftm-add-donation-site-answer" : "<a class='add-donation-site-form'> <button type='button' class='btn-sm btn-primary'>填寫此表格</button> </a>",
   "ftm-collaboration-with" : "與<a href=\".\" target=\"_blank\"> #findthemasks </a> 。",
   "ftm-address" : "地址",
   "ftm-org-type" : "組織類型",

--- a/sass/give.scss
+++ b/sass/give.scss
@@ -277,7 +277,7 @@ h3.city {
 #map {
   height: 400px;
   width: 100%;
-  margin-bottom: .3ex;
+  margin-bottom: 1rem;
 }
 
 #map .label {
@@ -311,6 +311,10 @@ h3.city {
   display: inline;
   margin: 0;
   padding: 0;
+}
+
+.add-donation-site-form {
+  line-height: 3;
 }
 
 .map-link {


### PR DESCRIPTION
* Add consistent 1rem bottom margin under all map embeds.
* Remove inline margin on add/edit donation form buttons for all languages.
* Style .add-donation-form in CSS instead using line height, that way it only creates margin between the button and the text when the design breaks with multiline text above it for small screens.