### PR TITLE
Make embed take up more of iframe height

### DIFF
--- a/sass/give.scss
+++ b/sass/give.scss
@@ -4,7 +4,7 @@
 @import "filter-styles";
 @import "breakpoints";
 
-$embed-body-height: 50vh;
+$embed-body-height: 70vh;
 $embed-body-height-sm: 35vh;
 
 html {


### PR DESCRIPTION
Now that the list view is shown side by side with the map, the map embed isn't really taking up the full height available in an iframe embed on desktop. 

Bumping up the embed body height to 70vh to fill up more of the height on large screens. This translates to a min iframe height of ~650px before scroll bars are shown on the embed. Takes up most of the iframe height now at more usable large iframe heights.

![ftm-before](https://user-images.githubusercontent.com/5592052/81380714-2f4e4280-90c0-11ea-8ca9-5d3f421ae6c8.jpg)
![ftm-after](https://user-images.githubusercontent.com/5592052/81380724-32493300-90c0-11ea-8834-2117ef516a95.jpg)

Note that pushing the iframe height past 750px starts making the white space gap noticeable again, but achieving true responsiveness is gonna more a more in depth change.