### PR TITLE
Change so hide-list has no effect on hide-filters

### DIFF
--- a/applicationRoutes.js
+++ b/applicationRoutes.js
@@ -55,9 +55,7 @@ router.get(['/give', '/give.html', '/embed'], (req, res) => {
     recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY,
     hideList: req.query['hide-list'] === 'true',
     hideMap: req.query['hide-map'] === 'true',
-    // NOTE: hide list currently hides filters...but that may change!
-    // if it does, this needs to change.
-    hideFilters: req.query['hide-filters'] === 'true' || req.query['hide-list'] === 'true',
+    hideFilters: req.query['hide-filters'] === 'true',
   });
 });
 

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1476,7 +1476,7 @@ $(() => {
   const renderListings = (result) => {
     const data = toDataByLocation(result);
     const showList = searchParams['hide-list'] !== 'true';
-    const showFilters = showList && searchParams['hide-filters'] !== 'true';
+    const showFilters = searchParams['hide-filters'] !== 'true';
     const showMap = searchParams['hide-map'] !== 'true';
 
     const $map = $('#map');
@@ -1508,14 +1508,13 @@ $(() => {
 
     $('.locations-loading').hide();
 
+    if (showFilters && areThereFilters(filters)) {
+      createFilterElements(data, filters);
+      $('.filters-container').show();
+    }
+
     if (showList) {
       $('.locations-container').show();
-
-      if (showFilters && areThereFilters(filters)) {
-        createFilterElements(data, filters);
-        $('.filters-container').show();
-      }
-
       refreshList(data, filters);
     }
   };


### PR DESCRIPTION
Previously, when a user set `hide-list=true` this would also enable `hide-filters=true` because the filters only worked on the list view in v1.

In the v2 world, filters work in either view (map or list), so it doesn't make sense for one feature to toggle another.