### PR TITLE
HACK: Always use the makers-us datafile contents

### DIFF
--- a/rootRoutes.js
+++ b/rootRoutes.js
@@ -77,8 +77,9 @@ router.get('/data(-:countryCode)?.json', (req, res) => {
 });
 
 router.get('/makers(-:countryCode)?.json', (req, res) => {
-  const countryCode = req.params.countryCode || 'us';
-  sendDataJsonFromCache(cachedMakersData, 'makers', countryCode, res);
+  // All make data is in one file right now. Currently calling it us, though
+  // "global" is probably the right name.
+  sendDataJsonFromCache(cachedMakersData, 'makers', 'us', res);
 });
 
 router.get('/data(-:countryCode)?.csv', createProxyMiddleware({


### PR DESCRIPTION
All data is in the makers-us.json datafile so serving that file
for all country-specific URLs.