### PR TITLE
Shift out widget creation and use template strings.

### DIFF
--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -8,7 +8,7 @@ import { FILTER_ITEMS, ORG_TYPES, ENUM_MAPPINGS } from './formEnumLookups.js';
 import { getMapsLanguageRegion } from './i18nUtils.js';
 import { ac, ce, ctn, FtmUrl } from './utils.js';
 import sendEvent from './sendEvent.js';
-import { createMapLink, getOneLineAddress, googleMapsUri } from './widgets.js'
+import { createMapLinkEl, getOneLineAddress, googleMapsUri } from './widgets.js'
 
 require('mobius1-selectr/src/selectr.css');
 
@@ -315,7 +315,7 @@ function createRequesterMarkerContent(entry, separator) {
   }
 
   if (address) {
-    let addressChildren = [createMapLink(address)];
+    let addressChildren = [createMapLinkEl(address)];
     if (rdi === 'Residential') {
       addressChildren = addressChildren.concat([
         ctn(' \u25CF '),

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -8,6 +8,7 @@ import { FILTER_ITEMS, ORG_TYPES, ENUM_MAPPINGS } from './formEnumLookups.js';
 import { getMapsLanguageRegion } from './i18nUtils.js';
 import { ac, ce, ctn, FtmUrl } from './utils.js';
 import sendEvent from './sendEvent.js';
+import { createMapLink, getOneLineAddress, googleMapsUri } from './widgets.js'
 
 require('mobius1-selectr/src/selectr.css');
 
@@ -227,27 +228,6 @@ function translateEnumList(enumListString) {
   }
 
   return enumListString;
-}
-
-function getOneLineAddress(address) {
-  return address.trim().replace(/\n/g, ', ');
-}
-
-function googleMapsUri(address) {
-  return encodeURI(`https://www.google.com/maps/search/?api=1&query=${address}`);
-}
-
-function createMapLink(address) {
-  // setup google maps link
-  const mapLinkEl = ce('a', 'map-link');
-  const oneLineAddress = getOneLineAddress(address);
-  mapLinkEl.href = googleMapsUri(oneLineAddress);
-  mapLinkEl.target = '_blank';
-  mapLinkEl.addEventListener('click', () => {
-    sendEvent('map', 'clickAddress', oneLineAddress);
-  });
-  mapLinkEl.appendChild(ctn(oneLineAddress));
-  return mapLinkEl;
 }
 
 // Turns a string with embedded \n characters into an Array of text nodes separated by <br>

--- a/client/widgets.js
+++ b/client/widgets.js
@@ -1,0 +1,24 @@
+import { ac, ce, ctn, FtmUrl } from './utils.js';
+
+function htmlToElements(html) {
+  return document.createRange().createContextualFragment(html).children;
+}
+
+export function getOneLineAddress(address) {
+  return address.trim().replace(/\n/g, ', ');
+}
+
+export function googleMapsUri(address) {
+  return encodeURI(`https://www.google.com/maps/search/?api=1&query=${address}`);
+}
+
+export function createMapLink(address) {
+  // setup google maps link
+  const oneLineAddress = getOneLineAddress(address);
+  const html =
+`<a class="map-link" href="${googleMapsUri(oneLineAddress)}" target="_blank"
+  click="sendEvent('map', 'clickAddress', ${oneLineAddress});">
+  ${oneLineAddress}
+</a>`;
+  return htmlToElements(html)[0];
+}


### PR DESCRIPTION
@saikat and @nick were noting that non-devs have a hard time making
even small content fixes because of the dynamically generated DOM.

They suggested using handlebars in the client but looking at our usage
it seems a template string might sufficient. Prototyping by moving
the widget content generation out into a separate file and replacing
the explicity dom node construction with just an HTML blob that is
given the the browser parser.

Fixes #902 