### PR TITLE
Small fixups

### DIFF
--- a/public/i18n/ar-ma.json
+++ b/public/i18n/ar-ma.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "البريد الإلكتروني:",
   "ftm-maps-marker-instructions-label" : "تعليمات:",
   "ftm-maps-marker-open-packages-label" : "الحزم المفتوحة ؟:",
-  "ftm-maps-search-placeholder" : "البحث عن طريق المدينة أو الرمز البريدي أو العنوان",
+  "ftm-maps-search-placeholder" : "البحث عن طريق الموقع",
   "ftm-maps-search-reset" : "إعادة تعيين قائمة الخريطة &",
   "ftm-maps-search-use-location" : "استخدم موقعي",
   "ftm-open-packages" : "فتح الحزم حسنا؟",

--- a/public/i18n/de-de.json
+++ b/public/i18n/de-de.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "Email:",
   "ftm-maps-marker-instructions-label" : "Anleitung:",
   "ftm-maps-marker-open-packages-label" : "Geöffnete Verpackungen oder Kartons?:",
-  "ftm-maps-search-placeholder" : "Suche nach Stadt, Postleitzahl oder Adresse",
+  "ftm-maps-search-placeholder" : "Suche nach Ort",
   "ftm-maps-search-reset" : "Liste & zurücksetzen",
   "ftm-maps-search-use-location" : "Nutze meinen Standort",
   "ftm-open-packages" : "Pakete öffnen OK?",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -90,7 +90,7 @@
   "ftm-info-window-email-contact": "Email:",
   "ftm-maps-marker-instructions-label": "Instructions:",
   "ftm-maps-marker-open-packages-label": "Open Packages?:",
-  "ftm-maps-search-placeholder": "Search by city, zip, or address",
+  "ftm-maps-search-placeholder": "Search by location",
   "ftm-maps-search-reset": "Reset map & list",
   "ftm-maps-search-use-location": "Use my location",
   "ftm-open-packages": "Open packages OK?",

--- a/public/i18n/es-es.json
+++ b/public/i18n/es-es.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "Correo electrónico:",
   "ftm-maps-marker-instructions-label" : "Instrucciones:",
   "ftm-maps-marker-open-packages-label" : "Paquetes abiertos ?:",
-  "ftm-maps-search-placeholder" : "Buscar por ciudad, código postal o dirección",
+  "ftm-maps-search-placeholder" : "Buscar por ubicación",
   "ftm-maps-search-reset" : "Restablecer mapa & lista",
   "ftm-maps-search-use-location" : "Usa mi ubicación",
   "ftm-open-packages" : "Abrir paquetes OK?",

--- a/public/i18n/fr-fr.json
+++ b/public/i18n/fr-fr.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "Email:",
   "ftm-maps-marker-instructions-label" : "Instructions:",
   "ftm-maps-marker-open-packages-label" : "Paquets ouverts?:",
-  "ftm-maps-search-placeholder" : "Entrer un code postal",
+  "ftm-maps-search-placeholder" : "Recherche par lieu",
   "ftm-maps-search-reset" : "Réinitialiser la liste de la carte &",
   "ftm-maps-search-use-location" : "Utiliser ma localisation",
   "ftm-open-packages" : "Ouvrir les packages OK?",

--- a/public/i18n/hi-in.json
+++ b/public/i18n/hi-in.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "ईमेल:",
   "ftm-maps-marker-instructions-label" : "निर्देश:",
   "ftm-maps-marker-open-packages-label" : "पैकेज खोलें ;:",
-  "ftm-maps-search-placeholder" : "शहर, ज़िप या पते द्वारा खोजें",
+  "ftm-maps-search-placeholder" : "स्थान के आधार पर खोजें",
   "ftm-maps-search-reset" : "मानचित्र & सूची को रीसेट करें",
   "ftm-maps-search-use-location" : "मेरा पता इस्तेमाल करो",
   "ftm-open-packages" : "पैकेज खोलें ठीक है?",

--- a/public/i18n/it-it.json
+++ b/public/i18n/it-it.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "E-mail:",
   "ftm-maps-marker-instructions-label" : "Istruzioni:",
   "ftm-maps-marker-open-packages-label" : "Pacchetti aperti ?:",
-  "ftm-maps-search-placeholder" : "Cerca per città, CAP o indirizzo",
+  "ftm-maps-search-placeholder" : "Cerca per posizione",
   "ftm-maps-search-reset" : "Reimposta elenco mappa &",
   "ftm-maps-search-use-location" : "Usa la mia posizione",
   "ftm-open-packages" : "Apri pacchetti OK?",

--- a/public/i18n/ja-jp.json
+++ b/public/i18n/ja-jp.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "Eメール：",
   "ftm-maps-marker-instructions-label" : "手順：",
   "ftm-maps-marker-open-packages-label" : "パッケージを開く？：",
-  "ftm-maps-search-placeholder" : "都市、郵便番号、または住所で検索",
+  "ftm-maps-search-placeholder" : "場所で検索",
   "ftm-maps-search-reset" : "マップ&リストをリセット",
   "ftm-maps-search-use-location" : "現在地を使用",
   "ftm-open-packages" : "パッケージを開きますか？",

--- a/public/i18n/ko-kr.json
+++ b/public/i18n/ko-kr.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "이메일:",
   "ftm-maps-marker-instructions-label" : "명령:",
   "ftm-maps-marker-open-packages-label" : "오픈 패키지? :",
-  "ftm-maps-search-placeholder" : "도시, 우편 번호 또는 주소로 검색",
+  "ftm-maps-search-placeholder" : "위치로 검색",
   "ftm-maps-search-reset" : "지도 & 목록 재설정",
   "ftm-maps-search-use-location" : "내 위치 사용",
   "ftm-open-packages" : "패키지 열기 OK?",

--- a/public/i18n/nl-nl.json
+++ b/public/i18n/nl-nl.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "E-mail adres:",
   "ftm-maps-marker-instructions-label" : "Instructies:",
   "ftm-maps-marker-open-packages-label" : "Open pakketten ?:",
-  "ftm-maps-search-placeholder" : "Zoek op stad, postcode of adres",
+  "ftm-maps-search-placeholder" : "Zoek op locatie",
   "ftm-maps-search-reset" : "Lijst met kaart & resetten",
   "ftm-maps-search-use-location" : "Gebruik mijn locatie",
   "ftm-open-packages" : "Pakketten openen OK?",

--- a/public/i18n/pl-pl.json
+++ b/public/i18n/pl-pl.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "E-mail:",
   "ftm-maps-marker-instructions-label" : "Instrukcje:",
   "ftm-maps-marker-open-packages-label" : "Otwarte pakiety ?:",
-  "ftm-maps-search-placeholder" : "Szukaj według miasta, kodu pocztowego lub adresu",
+  "ftm-maps-search-placeholder" : "Szukaj według lokalizacji",
   "ftm-maps-search-reset" : "Resetuj listę & map",
   "ftm-maps-search-use-location" : "Użyj mojej lokalizacji",
   "ftm-open-packages" : "Otwarte paczki OK?",

--- a/public/i18n/pt-pt.json
+++ b/public/i18n/pt-pt.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "O email:",
   "ftm-maps-marker-instructions-label" : "Instruções:",
   "ftm-maps-marker-open-packages-label" : "Abrir pacotes ?:",
-  "ftm-maps-search-placeholder" : "Pesquise por cidade, CEP ou endereço",
+  "ftm-maps-search-placeholder" : "Pesquisa por localização",
   "ftm-maps-search-reset" : "Redefinir lista do mapa &",
   "ftm-maps-search-use-location" : "Use minha localização",
   "ftm-open-packages" : "Pacotes abertos OK?",

--- a/public/i18n/ru-ru.json
+++ b/public/i18n/ru-ru.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "Электронное письмо:",
   "ftm-maps-marker-instructions-label" : "Инструкции:",
   "ftm-maps-marker-open-packages-label" : "Открытые пакеты ?:",
-  "ftm-maps-search-placeholder" : "Поиск по городу, почтовому индексу или адресу",
+  "ftm-maps-search-placeholder" : "Поиск по местоположению",
   "ftm-maps-search-reset" : "Сбросить карту & список",
   "ftm-maps-search-use-location" : "Используйте мое местоположение",
   "ftm-open-packages" : "Открытые пакеты в порядке?",

--- a/public/i18n/zh-tw.json
+++ b/public/i18n/zh-tw.json
@@ -87,7 +87,7 @@
   "ftm-info-window-email-contact" : "電子郵件：",
   "ftm-maps-marker-instructions-label" : "說明：",
   "ftm-maps-marker-open-packages-label" : "打開的包裝？：",
-  "ftm-maps-search-placeholder" : "按城市，郵政編碼或地址搜索",
+  "ftm-maps-search-placeholder" : "按位置搜尋",
   "ftm-maps-search-reset" : "重置地圖&列表",
   "ftm-maps-search-use-location" : "使用我的位置",
   "ftm-open-packages" : "打開的包裝好嗎？",

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -551,6 +551,8 @@ dl.faq-question {
   display: flex;
   min-height: 100%;
   align-items: center;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .navbar.ftm .navbar-brand {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -596,6 +596,10 @@ dl.faq-question {
   }
 }
 
+.navbar.ftm .nav-item {
+  white-space: nowrap;
+}
+
 .navbar.ftm .nav-item.show,
 .navbar.ftm .nav-item.show .nav-link:hover {
   background: #3f5cbb;
@@ -628,7 +632,6 @@ dl.faq-question {
   background: $pink;
   white-space: nowrap;
   font-weight: 600;
-  margin-left: 1rem;
   padding-left: 1rem;
   padding-right: 1.4rem;
 }
@@ -661,7 +664,6 @@ dl.faq-question {
   background: #fdc276;
   white-space: nowrap;
   font-weight: 600;
-  margin-left: 1rem;
   padding-left: 1rem;
   padding-right: 1.4rem;
 }
@@ -941,4 +943,20 @@ div.figure img {
 
 .contact-modal #message-text {
   height: 120px;
+}
+
+/****************************************************************
+  * NAVBAR LARGE TABLET / SMALL DESKTOP SIZE TRANSITIONAL STUFF *
+ ****************************************************************/
+
+@media (max-width: 1265px) and (min-width: $breakpoint-md) {
+  .navbar.ftm .navbar-nav .nav-link {
+    font-size: 10.5px;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  .navbar.ftm .btn-xlink, .navbar.ftm .btn-addplace {
+    font-size: 10.5px;
+  }
 }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -951,12 +951,12 @@ div.figure img {
 
 @media (max-width: 1265px) and (min-width: $breakpoint-md) {
   .navbar.ftm .navbar-nav .nav-link {
-    font-size: 10.5px;
+    font-size: 0.67rem;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
 
   .navbar.ftm .btn-xlink, .navbar.ftm .btn-addplace {
-    font-size: 10.5px;
+    font-size: 0.67rem;
   }
 }

--- a/views/give.handlebars
+++ b/views/give.handlebars
@@ -31,7 +31,7 @@
             </span>
           </div>
           <input type="search" name="map-search" id="map-search" class="i18n form-control border-0"
-            placeholder="Search by city, zip, or address" data-i18n="[placeholder]ftm-maps-search-placeholder">
+            placeholder="Search by location" data-i18n="[placeholder]ftm-maps-search-placeholder">
           <div class="input-group-append">
             <span class="input-group-text bg-white border-0">
               <a href="javascript:;" class="map-action-link" id="use-location">

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -42,7 +42,7 @@
             </div>
             <input type="search" name="map-search" id="map-search"
                    class="i18n form-control border-0"
-                   placeholder="Search by city, zip, or address"
+                   placeholder="Search by location"
                    data-i18n="[placeholder]ftm-maps-search-placeholder">
             <div class="input-group-append">
             <span class="input-group-text bg-white border-0">

--- a/views/special-projects/la-makers.handlebars
+++ b/views/special-projects/la-makers.handlebars
@@ -27,7 +27,7 @@
             </div>
             <input type="search" name="map-search" id="map-search"
                    class="i18n form-control border-0"
-                   placeholder="Search by city, zip, or address"
+                   placeholder="Search by location"
                    data-i18n="[placeholder]ftm-maps-search-placeholder">
             <div class="input-group-append">
             <span class="input-group-text bg-white border-0">


### PR DESCRIPTION
Address some small UI fixups:

#873, #913, #937 

To handle the layout on larger tablets or smaller desktop screens, shrink the font size and spacing a bit like so:

<img width="1043" alt="Screen Shot 2020-05-17 at 9 06 30 PM" src="https://user-images.githubusercontent.com/7133238/82173765-40970c00-9883-11ea-8528-2635471f5251.png">
