### PR TITLE
Add custom fullscreen logic to avoid GMap, Bstrap conflict

### DIFF
--- a/public/images/icons/growMap.svg
+++ b/public/images/icons/growMap.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 018 18">
+  <path fill="#666" d="M0,0v2v4h2V2h4V0H2H0z M16,0h-4v2h4v4h2V2V0H16z M16,16h-4v2h4h2v-2v-4h-2V16z M2,12H0v4v2h2h4v-2H2V12z"/>
+</svg>

--- a/public/images/icons/shrinkMap.svg
+++ b/public/images/icons/shrinkMap.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <path fill="#333" d="M4,4H0v2h6V0H4V4z M14,4V0h-2v6h6V4H14z M12,18h2v-4h4v-2h-6V18z M0,14h4v4h2v-6H0V14z"/>
+</svg>

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -8,7 +8,7 @@
   {{> top_nav }}
 
   <div class="row flex-lg-row no-gutters">
-    <div class="col-12 col-lg-6 search-filter-container">
+    <div id="filter-div" class="col-12 col-lg-6 search-filter-container">
       <div class="bg-white ">
         <div class="bg-dark-blue text-light">
 
@@ -70,7 +70,7 @@
       </div>
     </div>
 
-    <div class="col-12 col-lg-6">
+    <div id="map-div" class="col-12 col-lg-6">
       <div class="map-container">
         <div class="locations-loading text-center">
           <img src="/images/icons/loader.svg" alt="loading" class="load-spinner" />
@@ -81,6 +81,9 @@
           {{/if}}
         </div>
         <div id="map"></div>
+        <button id="customFullscreenButton" draggable="false" title="Toggle fullscreen view" type="button" style="display: none; background: none rgb(255, 255, 255); border: 0px; margin: 10px; padding: 0px; position: absolute; cursor: pointer; user-select: none; border-radius: 2px; height: 40px; width: 40px; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; overflow: hidden; top: 0px; right: 0px;">
+          <img id="customFullscreenImage" src="/images/icons/growMap.svg" style="height: 18px; width: 18px;">
+        </button>
       </div>
     </div>
 
@@ -97,7 +100,7 @@
       <div class="locations-container row no-gutters" style="display: none;">
         <div id="locations-list" class="locations-list col"></div>
       </div>
-      {{> contact_form}}
     </div>
   </div>
+  {{> contact_form}}
 </div>

--- a/views/partials/contact_form.handlebars
+++ b/views/partials/contact_form.handlebars
@@ -1,43 +1,40 @@
-<div id="contactModalContainer">
-  <div class="modal fade contact-modal" id="contactModal" tabindex="-1" role="dialog" aria-labelledby="contactModalLabel" aria-hidden="true" data-backdrop="false">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="contactModalLabel"></h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="contact-form">
-            <form>
-              <div class="form-group">
-                <input type="text" class="form-control i18n" id="sender-name" placeholder="Your Name" data-i18n="[placeholder]ftm-email-form-name-placeholder">
-              </div>
-              <div class="form-group">
-                <input type="text" class="form-control i18n" id="sender-email" placeholder="Your Email" data-i18n="[placeholder]ftm-email-form-email-placeholder">
-              </div>
-              <div class="form-group">
-                <input type="text" class="form-control i18n" id="message-subject" placeholder="Subject" data-i18n="[placeholder]ftm-email-form-subject-placeholder">
-              </div>
-              <div class="form-group">
-                <textarea class="form-control i18n" id="message-text" placeholder="Your Message" data-i18n="[placeholder]ftm-email-form-message-placeholder"></textarea>
-              </div>
-              <div class="g-recaptcha" data-sitekey="{{recaptchaSiteKey}}" data-size="compact"></div>
-            </form>
-            <div class="contact-error">&nbsp;</div>
-            <input type="hidden" id="message-recipient">
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-              <button type="button" class="btn btn-primary" id="send-message">Send message</button>
+<div class="modal fade contact-modal" id="contactModal" tabindex="-1" role="dialog" aria-labelledby="contactModalLabel" aria-hidden="true" data-backdrop="false">
+ <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="contactModalLabel"></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="contact-form">
+          <form>
+            <div class="form-group">
+              <input type="text" class="form-control i18n" id="sender-name" placeholder="Your Name" data-i18n="[placeholder]ftm-email-form-name-placeholder">
             </div>
+            <div class="form-group">
+              <input type="text" class="form-control i18n" id="sender-email" placeholder="Your Email" data-i18n="[placeholder]ftm-email-form-email-placeholder">
+            </div>
+            <div class="form-group">
+              <input type="text" class="form-control i18n" id="message-subject" placeholder="Subject" data-i18n="[placeholder]ftm-email-form-subject-placeholder">
+            </div>
+            <div class="form-group">
+              <textarea class="form-control i18n" id="message-text" placeholder="Your Message" data-i18n="[placeholder]ftm-email-form-message-placeholder"></textarea>
+            </div>
+            <div class="g-recaptcha" data-sitekey="{{recaptchaSiteKey}}" data-size="compact"></div>
+          </form>
+          <div class="contact-error">&nbsp;</div>
+          <input type="hidden" id="message-recipient">
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-primary" id="send-message">Send message</button>
           </div>
         </div>
-        <div class="contact-success i18n" data-i18n="ftm-email-sent-confirmation">
-          Your message was sent
-        </div>
+      </div>
+      <div class="contact-success i18n" data-i18n="ftm-email-sent-confirmation">
+        Your message was sent
       </div>
     </div>
   </div>
-  <div id="contactModalFullscreenContainer">
-  </div>
+</div>


### PR DESCRIPTION
When Google Maps fullscreen mode is activated, it interferes with Bootstrap modals, popovers, the CAPTCHA challenge window, etc. Any content that is not displayed through the Maps API is invisible, hidden "under" the map.

This disables Maps fullscreen mode and implements custom fullscreen logic that displays only the nav bar and the map. Since the map element is not in fullscreen mode, there is no interference with other content. 