### PR TITLE
Refresh list once

### DIFF
--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -704,13 +704,13 @@ function updateStats() {
 
   const prettyMarkerCount = numberFormat(countShown, 0);
   const prettyTotalCount = numberFormat(totalEntries, 0);
-  const stats = $('#list-stats');
-  stats.show();
+  const $stats = $('#list-stats');
+  $stats.show();
 
   if (gDataset === 'makers') {
-    stats.html($.i18n('ftm-makers-count', prettyMarkerCount, prettyTotalCount));
+    $stats.html($.i18n('ftm-makers-count', prettyMarkerCount, prettyTotalCount));
   } else {
-    stats.html($.i18n('ftm-requesters-count', prettyMarkerCount, prettyTotalCount));
+    $stats.html($.i18n('ftm-requesters-count', prettyMarkerCount, prettyTotalCount));
   }
 }
 
@@ -1135,10 +1135,6 @@ function initializeEmbedLocationCollapse() {
 }
 
 function refreshList(data, filters) {
-  if (!showList) {
-    return;
-  }
-
   gLocationsListEntries = getFlatFilteredEntries(data, filters);
   gLastLocationRendered = -1;
   $('.locations-list').empty();

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -65,6 +65,8 @@ let gLocationsListEntries = [];
 let gLastLocationRendered = -1;
 
 const searchParams = new FtmUrl(window.location.href).searchparams;
+const showList = searchParams['hide-list'] !== 'true';
+const showMap = searchParams['hide-map'] !== 'true';
 
 // tracks number of entries in dataset
 // gets set when we retrieve the dataset
@@ -679,20 +681,36 @@ function numberFormat(number, decimalPlaces, decSeparator, thouSeparator) {
 
 /**
  * Adjusts stats in header above map to call out number of markers currently being rendered.
- *
- * @param   $elem   jQuery selector for the stats element
- * @param   count   The number for render
- * @param   total   The total number of entries in the dataset
  */
-function updateStats($elem, count, total) {
-  const prettyMarkerCount = numberFormat(count, 0);
-  const prettyTotalCount = numberFormat(total, 0);
-  $elem.show();
+function updateStats() {
+  // Start with count of location list rows ...
+  let countShown = gLocationsListEntries.length;
+
+  if (showMap) {
+    if (!gMap) {
+      return;
+    }
+
+    const mapBounds = gMap.getBounds();
+    if (!mapBounds) {
+      return;
+    }
+
+    // ... but defer to count of markers in map bounds, when applicable.
+    const countInBounds = (count, marker) => count + mapBounds.contains(marker.getPosition());
+    countShown = gPrimaryMarkers.reduce(countInBounds, 0);
+    countShown += gSecondaryMarkers.reduce(countInBounds, 0);
+  }
+
+  const prettyMarkerCount = numberFormat(countShown, 0);
+  const prettyTotalCount = numberFormat(totalEntries, 0);
+  const stats = $('#list-stats');
+  stats.show();
 
   if (gDataset === 'makers') {
-    $elem.html($.i18n('ftm-makers-count', prettyMarkerCount, prettyTotalCount));
+    stats.html($.i18n('ftm-makers-count', prettyMarkerCount, prettyTotalCount));
   } else {
-    $elem.html($.i18n('ftm-requesters-count', prettyMarkerCount, prettyTotalCount));
+    stats.html($.i18n('ftm-requesters-count', prettyMarkerCount, prettyTotalCount));
   }
 }
 
@@ -798,8 +816,7 @@ function showMarkers(data, filters, recenterMap = true) {
 
   updateClusters(gPrimaryCluster, gSecondaryCluster);
 
-  const $mapStats = $('#map-stats');
-  updateStats($mapStats, markers.inFilters.length + markers.outOfFilters.length, totalEntries);
+  updateStats(); // filters have possibly changed
 
   // HACK. On some browsers, the markercluster freaks out if it gets a bunch of new markers
   // immediately followed by a map view change. Making the view change async works around
@@ -818,8 +835,6 @@ function getFlatFilteredEntries(data, filters) {
   const applied = filters.applied || {};
 
   const datasetFilters = filtersByDataset[gDataset];
-  let listCount = 0; // TODO: hacky, see note below.
-
   const { states, ...otherFilters } = applied;
 
   const otherFilterKeys = otherFilters && Object.keys(otherFilters).reduce((acc, otherFilterKey) => {
@@ -852,7 +867,6 @@ function getFlatFilteredEntries(data, filters) {
       }
     }
 
-    listCount++;
     entry.cityName = cityName;
     entry.stateName = stateName;
     entries.push(entry);
@@ -871,15 +885,6 @@ function getFlatFilteredEntries(data, filters) {
       const sortedEntries = city.entries.sort((a, b) => a.name.localeCompare(b.name));
       sortedEntries.forEach((entry) => onEntry(entry, cityName, stateName));
     }
-  }
-
-  // TODO: This is hacky since technically this function should ONLY be responsible for generating
-  // HTML snippets, not updating stats; however this is the quickest method for updating filter
-  // stats as well.
-  if (gMap) {
-    // if the map hasn't loaded yet, don't update requester count - otherwise it'll flash once
-    // the map uploads (depending on zoom level)
-    updateStats($('#list-stats'), listCount, totalEntries);
   }
 
   return entries;
@@ -1130,9 +1135,14 @@ function initializeEmbedLocationCollapse() {
 }
 
 function refreshList(data, filters) {
+  if (!showList) {
+    return;
+  }
+
   gLocationsListEntries = getFlatFilteredEntries(data, filters);
   gLastLocationRendered = -1;
   $('.locations-list').empty();
+  updateStats(); // number of locations in list has (probably) changed
   renderNextListPage();
   // initializes collapse logic on locations table if this is the embed
   if (isEmbed) {
@@ -1163,8 +1173,14 @@ function onFilterChange(data, prefix, idx, selected, filters) {
   });
 
   updateFilters(filters);
-  refreshList(data, filters);
-  showMarkers(data, filters, false);
+
+  if (showList) {
+    refreshList(data, filters);
+  }
+
+  if (showMap) {
+    showMarkers(data, filters, false);
+  }
 }
 
 // Creates the <select> elements for filters.
@@ -1524,14 +1540,22 @@ function initMap(data, filters) {
       const currentLat = mapBounds.getCenter().lat();
       const currentLng = mapBounds.getCenter().lng();
 
-      if (currentLat !== gCurrentViewportCenter.lat || currentLng !== gCurrentViewportCenter.lng) {
-        refreshList(data, filters);
+      if (showList) {
+        // When "changing" to initial bounds, the location list is already in sync,
+        //  *unless* the URL specified coordinates.
+        if ((gCurrentViewportCenter.lat && gCurrentViewportCenter.lat !== currentLat)
+          || (gCurrentViewportCenter.lng && gCurrentViewportCenter.lng !== currentLng)
+          || searchParams.coords) {
+          refreshList(data, filters);
+        }
       }
 
       gCurrentViewportCenter = {
         lat: currentLat,
         lng: currentLng,
       };
+
+      updateStats(); // number of markers in map bounds has (probably) changed
     }
   });
 
@@ -1643,9 +1667,7 @@ $(() => {
       .reduce((accumulator, currVal) => (accumulator + Object.keys(data[currVal].cities)
         .reduce((accum, curr) => (accum + data[currVal].cities[curr].entries.length), 0)), 0);
 
-    const showList = searchParams['hide-list'] !== 'true';
     const showFilters = searchParams['hide-filters'] !== 'true';
-    const showMap = searchParams['hide-map'] !== 'true';
 
     const $map = $('#map');
     // Second, allow an override from ?hide-search=[bool].

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1719,10 +1719,21 @@ $(() => {
     }
   });
 
-  const footerHeight = 40; // small buffer near bottom of window
-  $(window).scroll(() => {
-    if ($(window).scrollTop() + $(window).height() > $(document).height() - footerHeight) {
-      renderNextListPage();
+  if (showList) {
+    const footerHeight = 40; // small buffer near bottom of window
+
+    if (isEmbed) {
+      $('#locations-list').scroll(() => {
+        if ($('#locations-list').scrollTop() + $('#locations-list').innerHeight() > $('#locations-list')[0].scrollHeight - footerHeight) {
+          renderNextListPage();
+        }
+      });
+    } else {
+      $(window).scroll(() => {
+        if ($(window).scrollTop() + $(window).height() > $(document).height() - footerHeight) {
+          renderNextListPage();
+        }
+      });
     }
-  });
+  }
 });

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -349,14 +349,6 @@ h3.city {
   font-size: $font-size-small;
   padding-bottom: 6px;
 }
-#map-stats {
-  color: $text-color;
-  font-size: 22px;
-  font-weight: 300;
-  margin-left: 10px;
-  padding-top: 1px;
-  text-align: center;
-}
 
 .donation-map-title {
   align-items: center;

--- a/views/give.handlebars
+++ b/views/give.handlebars
@@ -70,7 +70,7 @@
       </div>
     </div>
 
-    <div class="col-12 {{#unless hideMap}}col-lg-4{{/unless}} order-lg-1 locations-container" style="height: 100px; display: none;">
+    <div class="col-12 {{#unless hideMap}}col-lg-4{{/unless}} order-lg-1 locations-container" style="display: none;">
       <div id="locations-list" class="locations-list {{#if hideMap}}w-100{{/if}}"></div>
     </div>
   </div>

--- a/views/give.handlebars
+++ b/views/give.handlebars
@@ -70,8 +70,8 @@
       </div>
     </div>
 
-    <div class="col-12 {{#unless hideMap}}col-lg-4{{/unless}} order-lg-1 locations-container" style="display: none;">
-      <div id="locations-list {{#if hideMap}}w-100{{/if}}" class="locations-list"></div>
+    <div class="col-12 {{#unless hideMap}}col-lg-4{{/unless}} order-lg-1 locations-container" style="height: 100px; display: none;">
+      <div id="locations-list" class="locations-list {{#if hideMap}}w-100{{/if}}"></div>
     </div>
   </div>
 


### PR DESCRIPTION
I noticed that `getFlatFilteredEntries` was being called twice on page load, which seemed kind of expensive. Both calls were coming from `refreshList`, which was called once explicitly, and once because map bounds were "changing" to their initial values.

I thought it might be pretty simple to avoid that redundancy. Much later, I have this, which eliminates all of these unneeded(?) steps:
- the redundancy already mentioned
- building the location list when `?hide-list=true`
- building the map markers when `?hide-map=true`

It also displays stats when `?hide-map=true`, which does not now happen in production. I think because of a bad/outdated jQuery selector that I modified.