### PR TITLE
Demo third-party links with real external web site

### DIFF
--- a/applicationRoutes.js
+++ b/applicationRoutes.js
@@ -8,6 +8,7 @@ const localizePartialPath = require('./viewHelpers/localizePartialPath');
 const getLocalContactEmail = require('./viewHelpers/getLocalContactEmail');
 const setBananaI18n = require('./middleware/setBananaI18n.js');
 const setCurrentUrl = require('./middleware/setCurrentUrl.js');
+const linkPartners = require('./linkPartners.js');
 
 const herokuVersion = process.env.HEROKU_RELEASE_VERSION;
 
@@ -43,15 +44,14 @@ router.get('/faq', (req, res) => {
   });
 });
 
-const linkPartners = [
-  'https://dewv.net/', // TODO build real site list; this is for testing (Steve Mattingly's site)
-];
-
 router.get(['/give', '/give.html', '/embed'], (req, res) => {
+  // Set up partner links, when applicable.
+  // req.headers.referer = "https://dewv.net/ftm/test.html"
   if (req.headers.referer) {
-    res.locals.partnerSite = linkPartners.find(
-      (element) => req.headers.referer.startsWith(element),
-    );
+    const referer = new URL(req.headers.referer);
+    if (linkPartners[referer.hostname]) {
+      res.locals.partnerSite = `${referer.origin}${linkPartners[referer.hostname]}`;
+    }
   }
 
   const isMaker = res.locals.dataset === 'makers';

--- a/applicationRoutes.js
+++ b/applicationRoutes.js
@@ -43,7 +43,13 @@ router.get('/faq', (req, res) => {
   });
 });
 
+const linkPartners = [
+  'https://dewv.net/', // TODO build real site list; this is for testing (Steve Mattingly's site)
+];
+
 router.get(['/give', '/give.html', '/embed'], (req, res) => {
+  res.locals.partnerSite = linkPartners.find((element) => req.header.referer.startsWith(element));
+
   const isMaker = res.locals.dataset === 'makers';
   res.render('give', {
     version: herokuVersion,

--- a/applicationRoutes.js
+++ b/applicationRoutes.js
@@ -48,7 +48,11 @@ const linkPartners = [
 ];
 
 router.get(['/give', '/give.html', '/embed'], (req, res) => {
-  res.locals.partnerSite = linkPartners.find((element) => req.header.referer.startsWith(element));
+  if (req.headers.referer) {
+    res.locals.partnerSite = linkPartners.find(
+      (element) => req.headers.referer.startsWith(element),
+    );
+  }
 
   const isMaker = res.locals.dataset === 'makers';
   res.render('give', {

--- a/applicationRoutes.js
+++ b/applicationRoutes.js
@@ -46,11 +46,11 @@ router.get('/faq', (req, res) => {
 
 router.get(['/give', '/give.html', '/embed'], (req, res) => {
   // Set up partner links, when applicable.
-  // req.headers.referer = "https://dewv.net/ftm/test.html"
   if (req.headers.referer) {
     const referer = new URL(req.headers.referer);
     if (linkPartners[referer.hostname]) {
       res.locals.partnerSite = `${referer.origin}${linkPartners[referer.hostname]}`;
+      res.locals.partnerStyleClass = `icon-${referer.hostname}`;
     }
   }
 

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1097,7 +1097,7 @@ function getEntryEl(entry) {
     zoomToMarker(entry.marker);
   });
   $(entry.domElem).find('.entry-partner-link').on('click', () => {
-    window.open(`${document.body.dataset.partnerSite}ftm?id=${entry.row}`, '_blank');
+    window.open(`${document.body.dataset.partnerSite}?id=${entry.row}`, '_blank');
   });
   $(entry.domElem).on('mouseenter', () => {
     sendEvent('listView', 'mouseover', entry.name);

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -952,12 +952,16 @@ function createRequesterListItemEl(entry) {
   entry.domElem = ce('div', 'location');
   const header = ce('div', 'd-flex');
   const headerHospitalInfo = ce('div', 'flex-grow-1');
+  const headerOrgType = ce('div', 'flex-grow-1 d-flex justify-content-end text-pink');
   const headerZoomLink = ce('div', 'icon icon-search entry-zoom-link');
   headerZoomLink.setAttribute('aria-label', 'Zoom to marker');
-  const headerExternalLink = ce('div', 'icon icon-search entry-external-link');
-  headerExternalLink.setAttribute('aria-label', 'External call to action');
-  const headerOrgType = ce('div', 'flex-grow-1 d-flex justify-content-end text-pink');
-  ac(headerHospitalInfo, ce('h5', null, [ctn(entry.name), headerZoomLink, headerExternalLink]));
+  const children = [ctn(entry.name), headerZoomLink];
+  if (document.body.dataset.partnerSite) {
+    const headerPartnerLink = ce('div', 'icon icon-search entry-partner-link'); // TODO replace icon
+    headerPartnerLink.setAttribute('aria-label', 'Partner site call to action');
+    children.push(headerPartnerLink);
+  }
+  ac(headerHospitalInfo, ce('h5', null, children));
 
   const { website } = entry;
 
@@ -1092,17 +1096,8 @@ function getEntryEl(entry) {
     sendEvent('listView', 'clickZoom', entry.name);
     zoomToMarker(entry.marker);
   });
-  $(entry.domElem).find('.entry-external-link').on('click', () => {
-    $.post(
-      'https://httpbin.org/post',
-      {
-        row: entry.row,
-        name: entry.name
-      }
-    ).done((response) => {
-      alert(`The external site processed your request concerning row ${response.form.row}, ${response.form.name}`)
-    }).fail((result) => {
-    });
+  $(entry.domElem).find('.entry-partner-link').on('click', () => {
+    window.open(`${document.body.dataset.partnerSite}ftm?id=${entry.row}`, '_blank');
   });
   $(entry.domElem).on('mouseenter', () => {
     sendEvent('listView', 'mouseover', entry.name);

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -957,7 +957,7 @@ function createRequesterListItemEl(entry) {
   headerZoomLink.setAttribute('aria-label', 'Zoom to marker');
   const children = [ctn(entry.name), headerZoomLink];
   if (document.body.dataset.partnerSite) {
-    const headerPartnerLink = ce('div', 'icon icon-search entry-partner-link'); // TODO replace icon
+    const headerPartnerLink = ce('div', `icon entry-partner-link ${document.body.dataset.partnerStyleClass}`);
     headerPartnerLink.setAttribute('aria-label', 'Partner site call to action');
     children.push(headerPartnerLink);
   }

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -949,8 +949,10 @@ function createRequesterListItemEl(entry) {
   const headerHospitalInfo = ce('div', 'flex-grow-1');
   const headerZoomLink = ce('div', 'icon icon-search entry-zoom-link');
   headerZoomLink.setAttribute('aria-label', 'Zoom to marker');
+  const headerExternalLink = ce('div', 'icon icon-search entry-external-link');
+  headerExternalLink.setAttribute('aria-label', 'External call to action');
   const headerOrgType = ce('div', 'flex-grow-1 d-flex justify-content-end text-pink');
-  ac(headerHospitalInfo, ce('h5', null, [ctn(entry.name), headerZoomLink]));
+  ac(headerHospitalInfo, ce('h5', null, [ctn(entry.name), headerZoomLink, headerExternalLink]));
 
   const { website } = entry;
 
@@ -1084,6 +1086,18 @@ function getEntryEl(entry) {
   $(entry.domElem).find('.entry-zoom-link').on('click', () => {
     sendEvent('listView', 'clickZoom', entry.name);
     zoomToMarker(entry.marker);
+  });
+  $(entry.domElem).find('.entry-external-link').on('click', () => {
+    $.post(
+      'https://httpbin.org/post',
+      {
+        row: entry.row,
+        name: entry.name
+      }
+    ).done((response) => {
+      alert(`The external site processed your request concerning row ${response.form.row}, ${response.form.name}`)
+    }).fail((result) => {
+    });
   });
   $(entry.domElem).on('mouseenter', () => {
     sendEvent('listView', 'mouseover', entry.name);

--- a/linkPartners.js
+++ b/linkPartners.js
@@ -1,0 +1,5 @@
+// TODO build real site list; this is for testing (Steve Mattingly's site)
+// Property keys are partner domains; values are path for link targets.
+module.exports = {
+  'dewv.net': '/ftm',
+};

--- a/linkPartners.js
+++ b/linkPartners.js
@@ -1,5 +1,15 @@
-// TODO build real site list; this is for testing (Steve Mattingly's site)
-// Property keys are partner domains; values are path for link targets.
+/*
+#findthemasks provides this file for partners to configure "callback" links to their sites.
+
+The example entry below means that all requests to FTM's embed with HTTP referer from example.com
+will receive responses with embedded links to example.com/target/path/for/links?id=X where X is a
+unique numeric identifier for the PPE requester. Full information on that requester can be accessed
+in findthemasks.com/data.json, matching X to the row id.
+
+See /scss/partner-link-icons.data.svg.scss to style the links.
+*/
+
 module.exports = {
+  'example.com': '/target/path/for/links',
   'dewv.net': '/ftm',
 };

--- a/sass/give.scss
+++ b/sass/give.scss
@@ -3,6 +3,7 @@
 @import "icons.data.svg";
 @import "filter-styles";
 @import "breakpoints";
+@import "partner-link-icons.data.svg";
 
 $embed-body-height: 70vh;
 $embed-body-height-sm: 35vh;

--- a/sass/give.scss
+++ b/sass/give.scss
@@ -88,7 +88,8 @@ footer {
     background-color: $gray;
   }
 
-  .entry-zoom-link {
+  .entry-zoom-link,
+  .entry-partner-link {
     cursor: pointer;
     display: inline-block;
     width: 24px;

--- a/sass/partner-link-icons.data.svg.scss
+++ b/sass/partner-link-icons.data.svg.scss
@@ -1,0 +1,15 @@
+/* 
+#findthemasks provides this file for partners to style their "callback" links.
+
+Each partner should define a CSS class named .icon-DOMAIN where DOMAIN is the same string used in
+linkPartners.js. Note that dots in the domain must be escaped with a single backslash.
+
+The example below configures callback links for example.com to use the Bootstrap emoji-sunglasses
+icon. The <svg> provided at https://icons.getbootstrap.com/icons/emoji-sunglasses/ is URL-encoded,
+then set as the background-image.
+*/
+
+.icon-dewv\.net {
+  background-image: url("data:image/svg+xml,%3Csvg%20class%3D%22bi%20bi-emoji-sunglasses%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22currentColor%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20fill-rule%3D%22evenodd%22%20d%3D%22M8%2015A7%207%200%201%200%208%201a7%207%200%200%200%200%2014zm0%201A8%208%200%201%200%208%200a8%208%200%200%200%200%2016z%22%2F%3E%0A%20%20%3Cpath%20fill-rule%3D%22evenodd%22%20d%3D%22M4.285%209.567a.5.5%200%200%201%20.683.183A3.498%203.498%200%200%200%208%2011.5a3.498%203.498%200%200%200%203.032-1.75.5.5%200%201%201%20.866.5A4.498%204.498%200%200%201%208%2012.5a4.498%204.498%200%200%201-3.898-2.25.5.5%200%200%201%20.183-.683zM6.5%206.497V6.5h-1c0-.568.447-.947.862-1.154C6.807%205.123%207.387%205%208%205s1.193.123%201.638.346c.415.207.862.586.862%201.154h-1v-.003l-.003-.01a.213.213%200%200%200-.036-.053.86.86%200%200%200-.27-.194C8.91%206.1%208.49%206%208%206c-.491%200-.912.1-1.19.24a.86.86%200%200%200-.271.194.213.213%200%200%200-.036.054l-.003.01z%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M2.31%205.243A1%201%200%200%201%203.28%204H6a1%201%200%200%201%201%201v1a2%202%200%200%201-2%202h-.438a2%202%200%200%201-1.94-1.515L2.31%205.243zM9%205a1%201%200%200%201%201-1h2.72a1%201%200%200%201%20.97%201.243l-.311%201.242A2%202%200%200%201%2011.439%208H11a2%202%200%200%201-2-2V5z%22%2F%3E%0A%3C%2Fsvg%3E");
+  background-repeat: no-repeat;
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -255,7 +255,8 @@ h3.city {
   &.highlighted {
     background-color: $gray;
   }
-
+  
+  .entry-external-link,
   .entry-zoom-link {
     cursor: pointer;
     display: inline-block;

--- a/views/layouts/give.handlebars
+++ b/views/layouts/give.handlebars
@@ -56,7 +56,7 @@
   <!-- END Open Graph Tags -->
 </head>
 
-<body data-dataset="{{dataset}}" data-country="{{countryCode}}" data-embed="true">
+<body data-dataset="{{dataset}}" data-country="{{countryCode}}" data-embed="true" data-partner-site="{{partnerSite}}">
 
   {{{body}}}
 

--- a/views/layouts/give.handlebars
+++ b/views/layouts/give.handlebars
@@ -56,7 +56,7 @@
   <!-- END Open Graph Tags -->
 </head>
 
-<body data-dataset="{{dataset}}" data-country="{{countryCode}}" data-embed="true" data-partner-site="{{partnerSite}}">
+<body data-dataset="{{dataset}}" data-country="{{countryCode}}" data-embed="true" data-partner-site="{{partnerSite}}" data-partner-style-class="{{partnerStyleClass}}">
 
   {{{body}}}
 


### PR DESCRIPTION
You can test this at https://dewv.net/ftm/test.html, where I have set up a demo of a mechanism for embedded third party links.

(Note second magnifying glass icon is temporarily used for the third party link.)
I think this approach is simple and reasonably abuse-proof.
For any and only sites that we put in the partner list, their embed requests will be served with links in the embed location list. Those site(s) will just need to handle `/ftm?id=X` requests.
