### PR TITLE
Disallow exceptions from one maker dataset to stop another from loading

### DIFF
--- a/functions/airtable-connector.js
+++ b/functions/airtable-connector.js
@@ -174,9 +174,19 @@ async function loadOsmsData() {
   return values;
 }
 
+async function logAndIgnoreException(f) {
+  try {
+    return await f() || [];
+  } catch (e) {
+    console.error(e);
+  }
+
+  return [];
+}
+
 async function loadMakerData(admin, req, res) {
-  const nomData = await loadNomData();
-  const osmsData = await loadOsmsData();
+  const nomData = await logAndIgnoreException(loadNomData);
+  const osmsData = await logAndIgnoreException(loadOsmsData);
 
   await writeMakerJson([...nomData, ...osmsData], admin, req, res);
 }


### PR DESCRIPTION
Was causing cascading failures.