### PR TITLE
850/rest filter boxes on reset map

### DIFF
--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1257,7 +1257,7 @@ function onFilterChange(data, prefix, idx, selected, filters, selectr) {
   }
   const temp = filters[prefix][Object.keys(filters[prefix])[idx]].name;
   if (selected) {
-    filterSelectors[temp]=selectr;
+    filterSelectors[temp] = selectr;
   } else {
     delete filterSelectors[temp];
   }
@@ -1536,8 +1536,8 @@ function initMapSearch(data, filters) {
     e.preventDefault();
     resetMap(data, filters);
     $search.val('');
-    Object.values(filterSelectors).forEach((current)=>{
-      current.clear();
+    Object.keys(filterSelectors).map((current) => {
+      filterSelectors[current].clear();
     });
     sendEvent('map', 'reset', 'default-location');
   });

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1536,7 +1536,7 @@ function initMapSearch(data, filters) {
     e.preventDefault();
     resetMap(data, filters);
     $search.val('');
-    Object.keys(filterSelectors).map((current) => {
+    Object.keys(filterSelectors).forEach((current) => {
       filterSelectors[current].clear();
     });
     sendEvent('map', 'reset', 'default-location');

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -49,9 +49,6 @@ let gSecondaryCluster = null;
 
 let gCurrentViewportCenter = {};
 
-// New object that stores key:value pairs between a filter and its corresponding Selector object
-const filterSelectors = {};
-
 const gDatasetMarkers = {
   requester: {
     standard: '/images/markers/requester_marker.svg',
@@ -1250,16 +1247,10 @@ function refreshList(data, filters) {
   }
 }
 
-function onFilterChange(data, prefix, idx, selected, filters, selectr) {
+function onFilterChange(data, prefix, idx, selected, filters) {
   const primaryFilter = filters[prefix] && filters[prefix][Object.keys(filters[prefix])[idx]];
   if (!primaryFilter) {
     return;
-  }
-  const temp = filters[prefix][Object.keys(filters[prefix])[idx]].name;
-  if (selected) {
-    filterSelectors[temp] = selectr;
-  } else {
-    delete filterSelectors[temp];
   }
   // Also apply filters that have the same display name
   const matchingFilterKeys = Object.keys(filters[prefix]).filter((filterKey) => {
@@ -1322,14 +1313,13 @@ function createFilterElements(data, filters) {
         searchable: false,
         placeholder: placeholderLabel,
       });
-
+      document.getElementById('filter-container').lastElementChild.selectrReference = selectr;
       selectr.on('selectr.select', (option) => {
-        onFilterChange(data, f, option.idx, true, filters, selectr);
+        onFilterChange(data, f, option.idx, true, filters);
         sendEvent('filters', f, option.value);
       });
-
       selectr.on('selectr.deselect', (option) => {
-        onFilterChange(data, f, option.idx, false, filters, selectr);
+        onFilterChange(data, f, option.idx, false, filters);
       });
     }
   }
@@ -1536,9 +1526,8 @@ function initMapSearch(data, filters) {
     e.preventDefault();
     resetMap(data, filters);
     $search.val('');
-    Object.keys(filterSelectors).forEach((current) => {
-      filterSelectors[current].clear();
-    });
+    document.getElementById('filter-container').lastElementChild.selectrReference.clear();
+    document.getElementById('filter-container').lastElementChild.previousSibling.selectrReference.clear();
     sendEvent('map', 'reset', 'default-location');
   });
 }

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -1528,6 +1528,8 @@ function initMapSearch(data, filters) {
     e.preventDefault();
     resetMap(data, filters);
     $search.val('');
+    $(".selectr-clear")[0].click();
+    $(".selectr-clear")[1].click();
     sendEvent('map', 'reset', 'default-location');
   });
 }

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -49,8 +49,8 @@ let gSecondaryCluster = null;
 
 let gCurrentViewportCenter = {};
 
-//New object that stores key:value pairs between a filter and its corresponding Selector object so we can clear them out when we reset the map
-let filter_selectors={};
+// New object that stores key:value pairs between a filter and its corresponding Selector object
+const filterSelectors = {};
 
 const gDatasetMarkers = {
   requester: {
@@ -1250,17 +1250,16 @@ function refreshList(data, filters) {
   }
 }
 
-function onFilterChange(data, prefix, idx, selected, filters,selectr) {
+function onFilterChange(data, prefix, idx, selected, filters, selectr) {
   const primaryFilter = filters[prefix] && filters[prefix][Object.keys(filters[prefix])[idx]];
   if (!primaryFilter) {
     return;
   }
-  let temp = filters[prefix][Object.keys(filters[prefix])[idx]].name;
-  if (selected){
-    filter_selectors[temp]=selectr;
-  }
-  else{
-    delete filter_selectors[temp];
+  const temp = filters[prefix][Object.keys(filters[prefix])[idx]].name;
+  if (selected) {
+    filterSelectors[temp]=selectr;
+  } else {
+    delete filterSelectors[temp];
   }
   // Also apply filters that have the same display name
   const matchingFilterKeys = Object.keys(filters[prefix]).filter((filterKey) => {
@@ -1325,12 +1324,12 @@ function createFilterElements(data, filters) {
       });
 
       selectr.on('selectr.select', (option) => {
-        onFilterChange(data, f, option.idx, true, filters,selectr);
+        onFilterChange(data, f, option.idx, true, filters, selectr);
         sendEvent('filters', f, option.value);
       });
 
       selectr.on('selectr.deselect', (option) => {
-        onFilterChange(data, f, option.idx, false, filters,selectr);
+        onFilterChange(data, f, option.idx, false, filters, selectr);
       });
     }
   }
@@ -1451,7 +1450,6 @@ function attemptGeocode(searchText) {
  */
 function resetMap(data, filters) {
   showMarkers(data, filters);
-  
 }
 
 /**
@@ -1538,7 +1536,7 @@ function initMapSearch(data, filters) {
     e.preventDefault();
     resetMap(data, filters);
     $search.val('');
-    Object.values(filter_selectors).forEach((current)=>{
+    Object.values(filterSelectors).forEach((current)=>{
       current.clear();
     });
     sendEvent('map', 'reset', 'default-location');


### PR DESCRIPTION
I edited the location-list-map.js so we can reference the Selector objects for the selected filters any time we select/deselect them. This allows us to go through these objects and deselect them upon resetting the map.