### PR TITLE
Made translations team blurb visible on Join Us page

### DIFF
--- a/views/volunteer.handlebars
+++ b/views/volunteer.handlebars
@@ -24,7 +24,7 @@
           Our Immediate Volunteer Needs:
         </h5>
         <!-- NOTE: just add "d-none" to the class of these divs to hide them !-->
-        <div class="volunteer-needs translation d-none">
+        <div class="volunteer-needs translation">
           <p>
             <strong>Translations</strong> - As we move into new countries, we need people who speak the official
             language(s) to help us check our translations, both for the web page and submission form. We have a machine


### PR DESCRIPTION
The Translations team blurb on the Join Us page is no longer invisible.