### PR TITLE
Update filter now also changes secondary datasets

### DIFF
--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -927,7 +927,7 @@ function centerMapToBounds(map, bounds, maxZoom) {
  * 'markers' module variable as well.
  */
 function showMarkers(data, filters, recenterMap = true) {
-  // console.log(data);
+
   if (!gMap || !gPrimaryCluster) {
     return;
   }
@@ -950,7 +950,6 @@ function showMarkers(data, filters, recenterMap = true) {
         icon: getIcon(gDatasetMarkers[gDataset].standard),
         datasetKey: gDataset,
       }).inFilters;
-      console.log(datasetData[secondDataKey].markers);
       gSecondaryMarkers.push(
         ...datasetData[secondDataKey].markers
       );

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -739,7 +739,6 @@ function getMarkers(data, appliedFilters, bounds, markerOptions) {
       }
     }
   }
-
   return {
     inFilters: inFiltersMarkers,
     outOfFilters: outOfFiltersMarkers,
@@ -928,6 +927,7 @@ function centerMapToBounds(map, bounds, maxZoom) {
  * 'markers' module variable as well.
  */
 function showMarkers(data, filters, recenterMap = true) {
+  // console.log(data);
   if (!gMap || !gPrimaryCluster) {
     return;
   }
@@ -944,9 +944,30 @@ function showMarkers(data, filters, recenterMap = true) {
   if (hasFilters) {
     gPrimaryMarkers = markers.inFilters;
     gSecondaryMarkers = markers.outOfFilters;
+    Object.keys(datasetData).forEach((secondDataKey) => {
+      const secondaryData = datasetData[secondDataKey].formattedDataset;
+      datasetData[secondDataKey].markers = getMarkers(secondaryData, applied, hasFilters && bounds, {
+        icon: getIcon(gDatasetMarkers[gDataset].standard),
+        datasetKey: gDataset,
+      }).inFilters;
+      console.log(datasetData[secondDataKey].markers);
+      gSecondaryMarkers.push(
+        ...datasetData[secondDataKey].markers
+      );
+    });
   } else {
     gPrimaryMarkers = markers.outOfFilters;
     gSecondaryMarkers = [];
+    Object.keys(datasetData).forEach((secondDataKey) => {
+      const secondaryData = datasetData[secondDataKey].formattedDataset;
+      datasetData[secondDataKey].markers = getMarkers(secondaryData, applied, hasFilters && bounds, {
+        icon: getIcon(gDatasetMarkers[gDataset].standard),
+        datasetKey: gDataset,
+      }).outOfFilters;
+      gSecondaryMarkers.push(
+        ...datasetData[secondDataKey].markers
+      );
+    });
   }
 
   if (gPrimaryCluster) {
@@ -1921,12 +1942,11 @@ function initMap(data, filters) {
               datasetData,
               {
                 [dataset.key]: {
-                  data,
+                  formattedDataset,
                   markers: getMarkers(formattedDataset, {}, null, markerOptions).outOfFilters,
                 },
               }
             );
-
             gSecondaryMarkers.push(
               ...datasetData[dataset.key].markers
             );

--- a/client/locations-list-map.js
+++ b/client/locations-list-map.js
@@ -927,7 +927,6 @@ function centerMapToBounds(map, bounds, maxZoom) {
  * 'markers' module variable as well.
  */
 function showMarkers(data, filters, recenterMap = true) {
-
   if (!gMap || !gPrimaryCluster) {
     return;
   }


### PR DESCRIPTION
To address the issue raised by @tobiasdeml, I just added some code to showMarkers() in location-list to check for additional datasets like makers. This should work for any additional datasets we want to potentially add in the future too!