### PR TITLE
Wrote basic unit tests for parseAirtableData()

### DIFF
--- a/functions/airtable-shared-view.js
+++ b/functions/airtable-shared-view.js
@@ -39,11 +39,8 @@ function createSelectTranslator(colMetadata) {
 
 function identityTranslator(x) { return x.trim(); }
 
-// Takes the airtable json from readSharedViewData and converts it into an array
-// of values in the style FindTheMasks expects.
-function parseAirtableData(airtableData) {
-  // Get all the column names and data translation setup.
-  //
+// Get all the column names and data translation setup.
+function mapColumns(airtableDataColumns) {
   // Column types are:
   // "type": "foreignKey",
   // "type": "formula",
@@ -53,7 +50,7 @@ function parseAirtableData(airtableData) {
   // "type": "select",
   // "type": "text",
   const columnNames = {};
-  for (const col of airtableData.data.table.columns) {
+  for (const col of airtableDataColumns) {
     const match = col.name.match(/\[(\S+)\]$/);
     if (match) {
       col.ftm_name = match[1];
@@ -70,6 +67,13 @@ function parseAirtableData(airtableData) {
 
     columnNames[col.id] = col;
   }
+  return columnNames;
+}
+
+// Takes the airtable json from readSharedViewData and converts it into an array
+// of values in the style FindTheMasks expects.
+function parseAirtableData(airtableData) {
+  const columnNames = mapColumns(airtableData.data.table.columns);
 
   // Go through data rows and create a data struct for us.
   const data = [];
@@ -95,4 +99,11 @@ function parseAirtableData(airtableData) {
   return data;
 }
 
-module.exports = { readAirtableSharedView, parseAirtableData };
+const unitTestFunctions = {
+  mapColumns, 
+  createMultiSelectTranslator,
+  createSelectTranslator,
+  identityTranslator,
+}
+
+module.exports = { readAirtableSharedView, unitTestFunctions, parseAirtableData };

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,7 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "jest"
+    "test": "jest --verbose"
   },
   "engines": {
     "node": "8"

--- a/functions/unittest/parseAirtable.test.js
+++ b/functions/unittest/parseAirtable.test.js
@@ -1,0 +1,70 @@
+const mockAirtable = require ('../airtable-shared-view.js');
+const { parseAirtableData } = require('../airtable-shared-view.js');
+
+describe('mapColumn() should detect any ftm-name in [] and set up the appropriate translator based on column type', () => {
+  const testColumn = [
+    {
+      name: 'This string should not be matched [matched-string]',
+      type: 'text',
+      id: 'first',
+    },
+    {
+      name: 'Nothing should match here',
+      type: 'select',
+      id: 'second',
+    },
+  ];  
+  test('If the column name has a string encapsulated in [], regex should match and a ftm-name property should be made', () => {
+    const copyTestColumn = JSON.parse(JSON.stringify(testColumn));
+    const returnColumns = mockAirtable.unitTestFunctions.mapColumns(copyTestColumn);
+    expect(returnColumns.first).toBeDefined();
+    expect(returnColumns.first.ftm_name).toEqual('matched-string');
+    expect(returnColumns.second.ftm_name).toBeUndefined();
+  });
+  test('There should be a default function for valueTranslator, specific functions should be used to match the column type', () => {
+    const copyTestColumn = JSON.parse(JSON.stringify(testColumn));
+    const returnColumns = mockAirtable.unitTestFunctions.mapColumns(copyTestColumn);
+    expect(returnColumns.first.valueTranslator).toEqual(mockAirtable.unitTestFunctions.identityTranslator);
+    expect(returnColumns.second.valueTranslator).not.toEqual(mockAirtable.unitTestFunctions.identityTranslator);
+    expect(returnColumns.second.valueTranslator).toEqual(expect.any(Function));
+  });
+});
+
+describe('parseAirtableData() should be able to go through each row and generate usable data structure for us', () => {
+  const testData = {
+    data: {
+      table: {
+        columns: [
+          {
+            name: 'This string should not be matched [matched-string]',
+            type: 'text',
+            id: 'first',
+          },
+          {
+            name: 'Nothing should match here',
+            type: 'text',
+            id: 'second',
+          },
+        ],
+        rows: [
+          {
+            id: 1,
+            cellValuesByColumnId: {
+              first: ' this string has an intial space to be trimmed by default valueTranslator',
+              second: 'the key for this data should not be the ftm_name',
+              third: 'This should not be part of the final data since it does not match a column'
+            },
+          },
+        ],
+      },
+    },
+  };
+  test('Code should go through each key-value pair in a row and generate a new data structure', () => {
+    const received = parseAirtableData(testData);
+    expect(received.length).toEqual(1);
+    expect(received[0].row).toEqual(1);
+    expect(received[0]['Nothing should match here']).toEqual('the key for this data should not be the ftm_name');
+    expect(received[0]['matched-string']).toEqual('this string has an intial space to be trimmed by default valueTranslator');
+    expect(Object.entries(received[0]).length).toEqual(3);
+  });
+});


### PR DESCRIPTION
This is the final method that @awong-dev suggested we play around with unit tests! Since Albert has always given us descriptions of the method and what to test for the previous 3 PRs, we wanted to challenge ourselves and do the same for this one. Here's what we have so far!

The method has 2 main functionality:

1. Map all the columns from the Airtable data to a new object, attaching new ftm-names whenever we match the regex in addition to specific value translators.

2.  Go through each row of the data and generate a useful data structure from it.

What we want to test:

For 1, we want to make sure that all columns are mapped to the new object. For columns that matches the regex, we create a new property called ftm_name with the matched string. Finally, we want to make sure all columns in the new object has a default value translator function with specific column types having a specific value translator.

For 2, we want to make sure that a new entry in the data object is generated for each row and that the key-value pairs for these entries contain the column name or ftm_name mapped to the translated value.

We think we were able to achieve most of the tests with a problem in checking the specific value translator functions since we can't check equality between anonymous functions inside the object. Please let us know what we should change/improve upon!
